### PR TITLE
docs: restructure README and tutorial around Agent, Tool, Trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ initrunner run researcher -a -p "Audit this codebase"   # let it work alone
 initrunner run researcher --daemon                      # runs 24/7, reacts to triggers
 ```
 
+Three nouns. Learn these first:
+
+- **Agent** is the thing you configure. One YAML file, one `spec:` block.
+- **Tools** are what the agent can do. `web_reader`, `filesystem`, `git`, `shell`, `sql`, and anything exposed by an MCP server.
+- **Triggers** are when it runs. Cron, webhook, file change, chat message, or nothing (run it yourself).
+
+Everything else in this README (memory, ingestion, autonomy, multi-agent, security) is optional. Skip it until you need it.
+
 ## Quickstart
 
 ```bash
@@ -148,21 +156,13 @@ initrunner run role.yaml --daemon   # runs until Ctrl+C
 
 Six trigger types: cron, webhook, file_watch, heartbeat, telegram, discord. The daemon hot-reloads role changes without restarting and runs up to 4 triggers concurrently. See [Triggers](docs/core/triggers.md).
 
-### Autopilot
-
-`--autopilot` is `--daemon` where every trigger gets the full autonomous loop. Someone messages your Telegram bot "find me flights from NYC to London next week." In daemon mode, you get one shot at an answer. In autopilot, the agent searches, compares options, checks dates, and sends back something worth reading.
-
-```bash
-initrunner run role.yaml --autopilot
-```
-
-You can also be selective. Set `autonomous: true` on individual triggers and leave the rest single-shot:
+Pair daemon with autonomous and you get `--autopilot`: every trigger fires the full plan-execute-reflect loop instead of a single-shot reply. Use this when a Telegram message like "find me flights from NYC to London next week" should kick off real work, not a one-line answer. Or set `autonomous: true` per trigger:
 
 ```yaml
 spec:
   triggers:
     - type: telegram
-      autonomous: true          # think, research, then reply
+      autonomous: true          # research, then reply
     - type: cron
       schedule: "0 9 * * 1"
       prompt: "Generate the weekly status report."
@@ -231,6 +231,10 @@ spec:
 ```
 
 Cost estimation uses [genai-prices](https://pypi.org/project/genai-prices/) to calculate actual spend per model and provider. Every run logs its cost to the audit trail. The dashboard shows cost analytics across agents and time ranges. See [Cost Tracking](docs/core/cost-tracking.md).
+
+---
+
+*Everything above is the first hour. Everything below is optional: reach for it when you need it.*
 
 ## Multi-agent orchestration
 

--- a/docs/getting-started/choosing-features.md
+++ b/docs/getting-started/choosing-features.md
@@ -2,6 +2,16 @@
 
 `AgentSpec` has 19 fields but only two are required: `role` and `model`. This page maps your goals to the specific fields you need to add. For interactive setup, use `initrunner setup` ([Setup Wizard](setup.md)). For a hands-on walkthrough, see the [Tutorial](tutorial.md).
 
+## First five minutes
+
+Three primitives carry 80% of what agents do. If this is your first time, read only these:
+
+- **Agent** is the thing you configure. One `role.yaml`, one `spec:` block.
+- **Tools** are what the agent can do. Add them under `spec.tools:`.
+- **Triggers** are when it runs. Add them under `spec.triggers:`, then launch with `--daemon`.
+
+Everything below this section (memory, ingestion, reasoning, autonomy, multi-agent patterns, security hardening) is optional. Reach for it when you need it, not before.
+
 ## Every Agent Needs These
 
 ```yaml

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -4,6 +4,16 @@ This hands-on tutorial walks you through building a **site monitor agent** — a
 
 Each step builds on the previous one and shows the **complete YAML** so you can copy-paste at any point.
 
+## The three primitives
+
+InitRunner has three moving parts. Everything else is a power-up.
+
+- **Agent** is the thing you configure. One YAML file, one `spec:` block. Step 1 below.
+- **Tools** are what the agent can do: `web_reader`, `filesystem`, `git`, `shell`, `sql`, and anything exposed by an MCP server. Step 3 below.
+- **Triggers** are when it runs: cron, webhook, file change, chat message, or nothing (run it yourself). Step 7 below.
+
+The steps between those (interactive mode, autonomous mode, memory, ingestion) are optional. Read them when you want them. A working agent does not need any of them.
+
 ## Prerequisites
 
 - **Python 3.11+** installed


### PR DESCRIPTION
## Summary
A new reader now meets three nouns (Agent / Tool / Trigger) before anything else.

- README: "Three nouns. Learn these first:" block after the opening snippet. Autopilot H3 folded into Daemon mode. "Going deeper" divider before Multi-agent.
- tutorial.md: new "The three primitives" section at the top; 7-step walk intact.
- choosing-features.md: new "First five minutes" block.

Docs-only. No schema, CLI, or slug changes.