### PR TITLE
docs(readme): tighten prose, refresh content, drop stale banner

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -25,20 +25,9 @@
   <a href="README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · 日本語
 </p>
 
-<p align="center">
-  <strong>2026.4.15 の新機能</strong><br>
-  暗号化クレデンシャルボールト · HMAC 署名済み監査チェーン · 双方向 Slack アダプター · 1 単語のスターター名 · <a href="CHANGELOG.md#202641515---2026-04-17">完全な変更履歴</a>
-</p>
-
 > **注意:** これはコミュニティによる翻訳です。最新の情報は [英語版 README](README.md) を参照してください。翻訳は更新に遅れる場合があります。
 
 1つの YAML ファイルでエージェントを定義。対話する。うまくいったら自律実行させる。信頼できたら、cron スケジュール、ファイル変更、webhook、Telegram メッセージに反応するデーモンとしてデプロイする。同じファイルのまま。プロトタイプから本番まで書き直し不要。
-
-```bash
-initrunner run researcher -i                            # 対話する
-initrunner run researcher -a -p "Audit this codebase"   # 自律的に作業させる
-initrunner run researcher --daemon                      # 24時間365日稼働、トリガーに反応
-```
 
 ## クイックスタート
 
@@ -51,16 +40,18 @@ initrunner setup        # ウィザード：プロバイダー、モデル、API
 
 ### スターター
 
-`initrunner run --list` で全カタログを表示。モデルは API キーから自動検出されます。
+ワンコマンドで実行できる 8 つのスターター。`initrunner run --list` でフルカタログを表示。モデルは API キーから自動検出されます。
 
 | スターター | 機能 |
 |-----------|------|
-| `helpdesk` | ドキュメントを読み込み、引用とメモリ付き Q&A エージェントを取得 |
-| `scholar` | 3 エージェントパイプライン：プランナー、Web リサーチャー、シンセサイザー |
-| `reviewer` | 多視点レビュー：アーキテクト、セキュリティ、メンテナー |
-| `reader` | リポジトリをインデックスし、アーキテクチャについて対話、セッション間でパターンを学習 |
-| `writer` | 調査、執筆、編集/ファクトチェック（webhook または cron 経由） |
+| `helpdesk` | ドキュメント（Markdown、PDF、HTML、Word）の Q&A エージェント。引用とユーザー別メモリ付き |
+| `scholar` | 3 エージェントの研究チーム：プランナー、Web リサーチャー、シンセサイザー（共有メモリ） |
+| `reviewer` | 多視点コードレビュー：アーキテクト、セキュリティ、メンテナー |
+| `reader` | コードベースをインデックスし、アーキテクチャを対話、パターンをセッション間で記憶 |
+| `scout` | 出典付きの構造化ブリーフィングを生成する Web 調査 |
+| `writer` | トピックから記事までのパイプライン：リサーチャー、ライター、編集・ファクトチェッカー、webhook または cron 駆動 |
 | `mail` | 受信トレイを監視、メッセージを分類、返信を起草、緊急メールを Slack に通知 |
+| `librarian` | ドキュメント取り込み付きのナレッジベース Q&A エージェント |
 
 ### 自分で作る
 
@@ -108,17 +99,17 @@ spec:
 このファイルは4つの方法で使えます：
 
 ```bash
-initrunner run reviewer.yaml -i              # インタラクティブ REPL
-initrunner run reviewer.yaml -p "Review PR #42"  # 1つのプロンプト、1つの応答
-initrunner run reviewer.yaml -a -p "Audit the whole repo"  # 自律モード：計画、実行、振り返り
-initrunner run reviewer.yaml --daemon        # 継続稼働、トリガーに反応
+initrunner run reviewer.yaml -i                          # インタラクティブ REPL
+initrunner run reviewer.yaml -p "Review PR #42"          # 1つのプロンプト、1つの応答
+initrunner run reviewer.yaml -a -p "Audit the whole repo"  # 自律ループ
+initrunner run reviewer.yaml --daemon                    # トリガー駆動で稼働
 ```
 
 `model:` セクションはオプション。省略すると InitRunner が API キーから自動検出します。Anthropic、OpenAI、Google、Groq、Mistral、Cohere、xAI、OpenRouter、Ollama、および任意の OpenAI 互換エンドポイントに対応。
 
 ### 自律モード
 
-`-a` を付けるとエージェントはチャットボットではなくなります。タスクリストを作り、各項目を処理し、自身の進捗を振り返り、すべて完了したら終了します。4つの推論戦略が思考方法を制御：`react`（デフォルト）、`todo_driven`、`plan_execute`、`reflexion`。
+`-a` を付けると、エージェントはタスクリストを作り、各項目を処理し、進捗を振り返り、すべて完了したら終了します。4つの推論戦略が思考方法を制御：`react`（デフォルト）、`todo_driven`、`plan_execute`、`reflexion`。
 
 ```yaml
 spec:
@@ -130,11 +121,11 @@ spec:
     autonomous_timeout_seconds: 600
 ```
 
-スピンガードが進展のないループを検出。ヒストリーコンパクションが古いコンテキストを要約し、長時間実行でもトークンウィンドウを圧迫しません。予算制約、イテレーション制限、ウォールクロックタイムアウトですべてが有界に。[自律実行](docs/orchestration/autonomy.md) · [ガードレール](docs/configuration/guardrails.md) を参照。
+スピンガードが進展のないループを検出。ヒストリーコンパクションが古いコンテキストを要約し、長時間実行でもトークンウィンドウを圧迫しません。イテレーション、トークン、ウォールクロックの上限が各実行を有界化します。[自律実行](docs/orchestration/autonomy.md) · [ガードレール](docs/configuration/guardrails.md) を参照。
 
-### デーモンモード
+### デーモン
 
-トリガーを追加して `--daemon` に切り替え。エージェントは継続稼働し、イベントに反応。各イベントが1回のプロンプト-応答サイクルを起動。
+トリガーを追加して `--daemon` に切り替え。エージェントは継続稼働し、各イベントが1回のプロンプト-応答サイクルを起動します。
 
 ```yaml
 spec:
@@ -149,21 +140,17 @@ spec:
       allowed_user_ids: [123456789]
 ```
 
-```bash
-initrunner run role.yaml --daemon   # Ctrl+C まで実行
-```
-
 6種類のトリガー：cron、webhook、file_watch、heartbeat、telegram、discord。再起動なしでロール変更をホットリロード、最大4トリガーを同時実行。[トリガー](docs/core/triggers.md) を参照。
 
 ### オートパイロット
 
-`--autopilot` は `--daemon` と同じですが、各トリガーが完全な自律ループを実行。Telegram ボットに「来週ニューヨークからロンドンへのフライトを探して」とメッセージが来たとき、デーモンモードでは1回で回答。オートパイロットでは、エージェントが Web を検索し、オプションを比較し、日程を確認し、読む価値のある回答を返します。
+`--autopilot` は `--daemon` にトリガーごとの自律ループを加えたもの。「来週ニューヨークからロンドンへのフライトを探して」という Telegram メッセージは、デーモンモードでは1回の LLM ターンで処理されます。オートパイロットでは、エージェントがフライトを検索し、オプションを比較し、日程を確認し、候補リストを返します。
 
 ```bash
 initrunner run role.yaml --autopilot
 ```
 
-選択的に設定することも可能。個別のトリガーに `autonomous: true` を設定し、残りはシングルショット応答のまま：
+選択的に有効化することも可能。個別のトリガーに `autonomous: true` を設定し、残りはシングルショットのまま：
 
 ```yaml
 spec:
@@ -177,16 +164,16 @@ spec:
     - type: file_watch
       paths: [./src]
       prompt_template: "File changed: {path}. Review it."
-      # デフォルト：クイックシングル応答
+      # デフォルト：単発応答
 ```
 
-### メモリはすべてを貫く
+### モードをまたぐメモリ
 
-エピソード記憶、セマンティック記憶、手続き記憶がインタラクティブセッション、自律実行、デーモントリガーの間で永続化。各セッション後、統合プロセスが LLM を使って会話から永続的な事実を抽出。エージェントは1回の実行内だけでなく、時間をかけてナレッジを蓄積します。
+セマンティック記憶（エージェントが学んだ事実）、エピソード記憶（過去のセッションで起きたこと）、手続き記憶（エージェントが好む解法）がインタラクティブセッション、自律実行、デーモントリガーの間で永続化されます。各セッション後、LLM が永続的な事実をストアに統合します。ナレッジは1回の実行内だけでなく、時間をかけて蓄積されます。
 
 ## 学習するエージェント
 
-エージェントをディレクトリに向けるだけ。ドキュメントを自動的に抽出、チャンク分割、埋め込み、インデックス。会話中、エージェントは自動でインデックスを検索し、見つけた内容を引用。新規・変更ファイルは毎回の実行で自動再インデックス。
+エージェントをディレクトリに向けるだけ。ドキュメントを自動的に抽出、チャンク分割、埋め込み、インデックスします。会話中、エージェントは自動でインデックスを検索し、見つけた内容を引用。新規・変更ファイルは毎回の実行で再インデックスされます。
 
 ```yaml
 spec:
@@ -203,32 +190,37 @@ cd ~/myproject
 initrunner run reader -i   # コードをインデックスし、Q&A を開始
 ```
 
-重要なのは統合です。各セッション後、LLM が何が起きたかを読み取り、セマンティックストアに蒸留します。火曜日のデバッグセッションで学んだ事実が、木曜日のコードレビュー時に現れます。Flow の共有メモリにより、エージェントチームが共同でナレッジを構築。[メモリ](docs/core/memory.md) · [取り込み](docs/core/ingestion.md) · [RAG クイックスタート](docs/getting-started/rag-quickstart.md) を参照。
+重要なのは統合です。各セッション後、LLM が会話を読み取り、セマンティックストアに蒸留します。火曜日のデバッグセッションで学んだ事実が、木曜日のコードレビュー時に現れます。Flow の共有メモリにより、エージェントチームが共同でナレッジを構築。[メモリ](docs/core/memory.md) · [取り込み](docs/core/ingestion.md) · [RAG クイックスタート](docs/getting-started/rag-quickstart.md) を参照。
 
-## セキュリティは標準装備
+## セキュリティ
 
-ほとんどのエージェントフレームワークはセキュリティを「本番になったら認証ミドルウェアを追加」として扱います。InitRunner はこれらの制御を標準で同梱。設定キーで有効化するだけです。
+フレームワークに同梱され、設定キーで有効化できる5つの制御。`security:` セクションのないロールは安全なデフォルト値で動作します。
 
-**エージェントは信頼できない入力を受け付ける。** コンテンツポリシーエンジン（禁止パターン、プロンプト長制限、オプションの LLM トピック分類器）と入力ガードケイパビリティがエージェント開始前にプロンプトを検証。
+**入力検証。** コンテンツポリシーエンジン（禁止パターン、プロンプト長制限、オプションの LLM トピック分類器）と入力ガードケイパビリティが、エージェント開始前にプロンプトを検証。
 
-**エージェントは実際の影響があるツールを呼び出す。** [InitGuard](https://github.com/initrunner/initguard) ABAC ポリシーエンジンがすべてのツール呼び出しと委任を CEL ポリシーに対してチェック。ツールごとの allow/deny glob パターンで引数レベルのパーミッションを適用。
+**ツール認可。** [InitGuard](https://github.com/initrunner/initguard) ABAC ポリシーエンジンがすべてのツール呼び出しと委任を CEL ポリシーに対してチェック。ツールごとの allow/deny glob パターンで引数レベルのパーミッションを適用。
 
-**エージェントはコードを実行する。** PEP 578 監査フックサンドボックスがファイルシステム書き込みを制限、サブプロセス生成をブロック、プライベート IP ネットワークアクセスをブロック、危険なインポートを防止。Docker コンテナサンドボックスが読み取り専用 rootfs、メモリ/CPU 制限、ネットワーク分離を追加。
+**コード実行サンドボックス。** PEP 578 監査フックが、許可リスト外のファイル書き込み、`subprocess.Popen` と `os.system`（デフォルト）、プライベート IP への `socket.connect` をブロックし、`ctypes.dlopen` と新規スレッドは常にブロックします。Docker コンテナサンドボックスが読み取り専用 rootfs、メモリ/CPU 制限、ネットワーク分離を追加。
 
-**すべてが記録される。** 追記専用 SQLite 監査証跡、自動シークレットスクラブ。正規表現パターンがプロンプトと出力から GitHub トークン、AWS キー、Stripe キーなどを除去。
+**改ざん検知可能な監査証跡。** 各実行は追記専用 SQLite 監査ログに書き込まれ、前のレコードのハッシュに対して HMAC-SHA256 で署名されます。`initrunner audit verify-chain` が中間レコードの変更、並び替え、削除を検出。シークレットは書き込み時にスクラブされます。
 
-これらはすべて `security:` 設定キーによるオプトイン方式です。`security:` セクションのないロールには安全なデフォルト値が適用されます。
+**暗号化クレデンシャルボールト。** `initrunner vault init` で `~/.initrunner/vault.enc` を作成し、パスフレーズから Fernet + scrypt で暗号化します。API キーは環境変数を最初に参照し、次にボールトを参照するので、既存の `api_key_env:` や `${VAR}` プレースホルダーはそのまま動作します。
 
-```bash
-export INITRUNNER_POLICY_DIR=./policies
-initrunner run role.yaml    # ツール呼び出し + 委任をポリシーに対してチェック
+```yaml
+spec:
+  security:
+    audit_hooks_enabled: true
+    block_private_ips: true
+    input_guard:
+      max_prompt_chars: 10000
+      blocked_patterns: ["(?i)rm -rf /"]
 ```
 
-[エージェントポリシー](docs/security/agent-policy.md) · [セキュリティ](docs/security/security.md) · [ガードレール](docs/configuration/guardrails.md) を参照。
+[セキュリティ](docs/security/security.md) · [エージェントポリシー](docs/security/agent-policy.md) · [クレデンシャルボールト](docs/security/vault.md) · [監査チェーン](docs/security/audit-chain.md) · [ガードレール](docs/configuration/guardrails.md) を参照。
 
 ## コスト管理
 
-ほとんどのフレームワークはトークン予算を追跡します。InitRunner はそれに加えて USD コスト予算も強制適用。デーモンに日次または週次のドル上限を設定し、閾値に達したらトリガーの発火を停止。
+USD 予算がデーモンの支出に上限を設定。上限に達するとトリガーの発火は停止し、ウィンドウがリセットされるまで再開しません。
 
 ```yaml
 spec:
@@ -237,11 +229,11 @@ spec:
     daemon_weekly_cost_budget: 25.00  # 週あたり USD
 ```
 
-コスト見積もりは [genai-prices](https://pypi.org/project/genai-prices/) を使用して、モデルとプロバイダーごとの実際の支出を計算。各実行のコストは監査証跡に記録。ダッシュボードではエージェントと期間を横断したコスト分析を表示。[コスト追跡](docs/core/cost-tracking.md) を参照。
+コスト見積もりは [genai-prices](https://pypi.org/project/genai-prices/) でモデルとプロバイダーごとに計算します。各実行のコストは監査証跡に記録。ダッシュボードはエージェントと期間を横断したコストをプロットします。[コスト追跡](docs/core/cost-tracking.md) を参照。
 
 ## マルチエージェントオーケストレーション
 
-エージェントを Flow に連鎖。あるエージェントの出力が次の入力に。センスルーティングがまずキーワードスコアリングでターゲットを自動選択（API 呼び出しゼロ）、キーワードが曖昧な場合のみ LLM でタイブレーク：
+エージェントを Flow に連鎖。あるエージェントの出力が次の入力になります。
 
 ```yaml
 apiVersion: initrunner/v1
@@ -262,6 +254,8 @@ spec:
 ```bash
 initrunner flow up flow.yaml
 ```
+
+センスルーティングはまずキーワードスコアリングでターゲットを選択（API 呼び出しゼロ）し、キーワードが曖昧な場合のみ LLM のタイブレークにフォールバックします。
 
 **チームモード** は、完全な Flow を構築するほどではないが、1つのタスクに複数の視点が必要な場合に使用。1つのファイルでペルソナを定義、3つの戦略：順次ハンドオフ、並列実行、またはディベート（多ラウンドの議論と統合）。[パターンガイド](docs/orchestration/patterns-guide.md) · [チームモード](docs/orchestration/team_mode.md) · [Flow](docs/orchestration/flow.md) を参照。
 
@@ -328,11 +322,6 @@ initrunner/
 
 **OCI レジストリ:** ロールバンドルを任意の OCI 準拠レジストリにプッシュ: `initrunner publish oci://ghcr.io/org/my-agent --tag 1.0.0`。[OCI 配布](docs/core/oci-distribution.md) を参照。
 
-**クラウドデプロイ:**
-
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/FROM_REPO?referralCode=...)
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/vladkesler/initrunner)
-
 ## ドキュメント
 
 | 領域 | 主要ドキュメント |
@@ -345,7 +334,7 @@ initrunner/
 | オーケストレーション | [Patterns Guide](docs/orchestration/patterns-guide.md) · [Flow](docs/orchestration/flow.md) · [Delegation](docs/orchestration/delegation.md) · [Team Mode](docs/orchestration/team_mode.md) · [Triggers](docs/core/triggers.md) |
 | インターフェース | [Dashboard](docs/interfaces/dashboard.md) · [API Server](docs/interfaces/server.md) · [MCP Gateway](docs/interfaces/mcp-gateway.md) · [A2A](docs/interfaces/a2a.md) |
 | 配布 | [OCI Distribution](docs/core/oci-distribution.md) · [Shareable Templates](docs/getting-started/shareable-templates.md) |
-| セキュリティ | [Security Model](docs/security/security.md) · [Agent Policy](docs/security/agent-policy.md) · [Guardrails](docs/configuration/guardrails.md) |
+| セキュリティ | [Security Model](docs/security/security.md) · [Credential Vault](docs/security/vault.md) · [Audit Chain](docs/security/audit-chain.md) · [Agent Policy](docs/security/agent-policy.md) · [Guardrails](docs/configuration/guardrails.md) |
 | 運用 | [Audit](docs/core/audit.md) · [Cost Tracking](docs/core/cost-tracking.md) · [Reports](docs/core/reports.md) · [Evals](docs/core/evals.md) · [Doctor](docs/operations/doctor.md) · [Observability](docs/core/observability.md) · [CI/CD](docs/operations/cicd.md) |
 
 ## サンプル
@@ -357,7 +346,7 @@ initrunner examples copy code-reviewer # カレントディレクトリにコピ
 
 ## アップグレード
 
-`initrunner doctor --role role.yaml` でロールファイルの非推奨フィールド、スキーマエラー、仕様バージョンの問題をチェック。`--fix` で自動修復。[非推奨事項](docs/operations/deprecations.md) を参照。
+`initrunner doctor --role role.yaml` でロールファイルの非推奨フィールド、スキーマエラー、仕様バージョンの問題をチェック。`--fix` で自動修復。`--flow flow.yaml` で Flow 全体とその参照先ロールを検証。[非推奨事項](docs/operations/deprecations.md) を参照。
 
 ## コミュニティ
 
@@ -372,4 +361,4 @@ initrunner examples copy code-reviewer # カレントディレクトリにコピ
 
 ---
 
-<p align="center"><sub>v2026.4.12</sub></p>
+<p align="center"><sub>v2026.4.15</sub></p>

--- a/README.md
+++ b/README.md
@@ -25,18 +25,7 @@
   English · <a href="README.zh-CN.md">简体中文</a> · <a href="README.ja.md">日本語</a>
 </p>
 
-<p align="center">
-  <strong>What's new in 2026.4.15</strong><br>
-  encrypted credential vault · HMAC-signed audit chain · bidirectional Slack adapter · one-word starter names · <a href="CHANGELOG.md#202641515---2026-04-17">full changelog</a>
-</p>
-
 Define an agent in one YAML file. Chat with it. When it works, let it run autonomously. When you trust it, deploy it as a daemon that reacts to cron schedules, file changes, webhooks, and Telegram messages. Same file the whole way. No rewrite between prototyping and production.
-
-```bash
-initrunner run researcher -i                            # chat with it
-initrunner run researcher -a -p "Audit this codebase"   # let it work alone
-initrunner run researcher --daemon                      # runs 24/7, reacts to triggers
-```
 
 ## Quickstart
 
@@ -49,16 +38,18 @@ Or: `uv pip install "initrunner[recommended]"` / `pipx install "initrunner[recom
 
 ### Starters
 
-Run `initrunner run --list` for the full catalog. The model is auto-detected from your API key.
+Eight starters you can run in one command. Browse the full catalog with `initrunner run --list`. The model is auto-detected from your API key.
 
 | Starter | What it does |
 |---------|-------------|
-| `helpdesk` | Drop your docs in, get a Q&A agent with citations and memory |
-| `scholar` | 3-agent pipeline: planner, web researcher, synthesizer |
-| `reviewer` | Multi-perspective review: architect, security, maintainer |
-| `reader` | Index a repo, chat about architecture, learns patterns across sessions |
-| `writer` | Researcher, writer, editor/fact-checker via webhook or cron |
+| `helpdesk` | Q&A agent over your docs (markdown, PDF, HTML, Word) with citations and per-user memory |
+| `scholar` | Three-agent research team: planner, web researcher, synthesizer, with shared memory |
+| `reviewer` | Multi-perspective code review: architect, security, maintainer |
+| `reader` | Index a codebase, chat about architecture, remember patterns across sessions |
+| `scout` | Web research with structured briefings and sourced citations |
+| `writer` | Topic-to-article pipeline: researcher, writer, editor/fact-checker, driven by webhook or cron |
 | `mail` | Monitors inbox, triages, drafts replies, alerts Slack on urgent mail |
+| `librarian` | Knowledge-base Q&A agent with document ingestion |
 
 ### Build your own
 
@@ -106,17 +97,17 @@ spec:
 That file works four ways:
 
 ```bash
-initrunner run reviewer.yaml -i              # interactive REPL
-initrunner run reviewer.yaml -p "Review PR #42"  # one prompt, one response
-initrunner run reviewer.yaml -a -p "Audit the whole repo"  # autonomous: plans, executes, reflects
-initrunner run reviewer.yaml --daemon        # runs continuously, fires on triggers
+initrunner run reviewer.yaml -i                          # interactive REPL
+initrunner run reviewer.yaml -p "Review PR #42"          # one prompt, one response
+initrunner run reviewer.yaml -a -p "Audit the whole repo"  # autonomous loop
+initrunner run reviewer.yaml --daemon                    # runs on triggers
 ```
 
-The `model:` section is optional. Omit it and InitRunner auto-detects from your API key. Works with Anthropic, OpenAI, Google, Groq, Mistral, Cohere, xAI, OpenRouter, Ollama, and any OpenAI-compatible endpoint.
+The `model:` block is optional. Omit it and InitRunner auto-detects from your API key. Works with Anthropic, OpenAI, Google, Groq, Mistral, Cohere, xAI, OpenRouter, Ollama, and any OpenAI-compatible endpoint.
 
-### Autonomous mode
+### Autonomous
 
-Add `-a` and the agent stops being a chatbot. It builds a task list, works through each item, reflects on its own progress, and finishes when everything is done. Four reasoning strategies control how: `react` (default), `todo_driven`, `plan_execute`, and `reflexion`.
+Add `-a` and the agent builds a task list, works each item, reflects on progress, and stops when everything's done. Four reasoning strategies control how: `react` (default), `todo_driven`, `plan_execute`, `reflexion`.
 
 ```yaml
 spec:
@@ -128,11 +119,11 @@ spec:
     autonomous_timeout_seconds: 600
 ```
 
-Spin guards catch the agent if it loops without making progress. History compaction summarizes old context so long runs don't blow up the token window. Budget enforcement, iteration limits, and wall-clock timeouts keep everything bounded. See [Autonomy](docs/orchestration/autonomy.md) · [Guardrails](docs/configuration/guardrails.md).
+Spin guards catch loops without progress. History compaction summarizes old context so long runs don't exhaust the token window. Iteration, token, and wall-clock caps bound every run. See [Autonomy](docs/orchestration/autonomy.md) · [Guardrails](docs/configuration/guardrails.md).
 
-### Daemon mode
+### Daemon
 
-Add triggers and switch to `--daemon`. The agent runs continuously, reacting to events. Each event fires a prompt-response cycle.
+Add triggers and switch to `--daemon`. The agent runs continuously. Each event fires one prompt-response cycle.
 
 ```yaml
 spec:
@@ -147,21 +138,17 @@ spec:
       allowed_user_ids: [123456789]
 ```
 
-```bash
-initrunner run role.yaml --daemon   # runs until Ctrl+C
-```
-
-Six trigger types: cron, webhook, file_watch, heartbeat, telegram, discord. The daemon hot-reloads role changes without restarting and runs up to 4 triggers concurrently. See [Triggers](docs/core/triggers.md).
+Six trigger types: cron, webhook, file_watch, heartbeat, telegram, discord. The daemon hot-reloads role changes without restarting and runs up to four triggers concurrently. See [Triggers](docs/core/triggers.md).
 
 ### Autopilot
 
-`--autopilot` is `--daemon` where every trigger gets the full autonomous loop. Someone messages your Telegram bot "find me flights from NYC to London next week." In daemon mode, you get one shot at an answer. In autopilot, the agent searches, compares options, checks dates, and sends back something worth reading.
+`--autopilot` is `--daemon` plus the autonomous loop on every trigger. A Telegram message like "find me flights from NYC to London next week" in daemon mode gets one LLM turn. In autopilot, the agent searches flights, compares options, checks dates, and replies with a shortlist.
 
 ```bash
 initrunner run role.yaml --autopilot
 ```
 
-You can also be selective. Set `autonomous: true` on individual triggers and leave the rest single-shot:
+Or go selective: set `autonomous: true` on individual triggers, leave the rest single-shot.
 
 ```yaml
 spec:
@@ -175,16 +162,16 @@ spec:
     - type: file_watch
       paths: [./src]
       prompt_template: "File changed: {path}. Review it."
-      # default: quick single response
+      # default: single response
 ```
 
-### Memory carries across everything
+### Memory across modes
 
-Episodic, semantic, and procedural memory persist across interactive sessions, autonomous runs, and daemon triggers. After each session, consolidation extracts durable facts from the conversation using an LLM. The agent accumulates knowledge over time, not just within a single run.
+Semantic memory (facts the agent learns), episodic memory (what happened in past sessions), and procedural memory (how the agent prefers to solve things) persist across interactive sessions, autonomous runs, and daemon triggers. After each session, an LLM consolidates durable facts into the store. Knowledge accumulates over time, not just within a single run.
 
 ## Agents that learn
 
-Point your agent at a directory. It extracts, chunks, embeds, and indexes your documents automatically. During conversation, the agent searches the index and cites what it finds. New and changed files are re-indexed on every run without manual intervention.
+Point your agent at a directory. It extracts, chunks, embeds, and indexes your documents automatically. During conversation, the agent searches the index and cites what it finds. New and changed files re-index on every run.
 
 ```yaml
 spec:
@@ -201,32 +188,37 @@ cd ~/myproject
 initrunner run reader -i   # indexes your code, then starts Q&A
 ```
 
-The interesting part is consolidation. After each session, an LLM reads what happened and distills it into the semantic store. Facts the agent learns during a Tuesday debugging session show up when it's reviewing code on Thursday. Shared memory across flows lets teams of agents build knowledge together. See [Memory](docs/core/memory.md) · [Ingestion](docs/core/ingestion.md) · [RAG Quickstart](docs/getting-started/rag-quickstart.md).
+Consolidation is the interesting part. After each session, an LLM reads the conversation and distills it into the semantic store. Facts the agent learns during a Tuesday debugging session show up when it's reviewing code on Thursday. Shared memory across flows lets teams of agents build knowledge together. See [Memory](docs/core/memory.md) · [Ingestion](docs/core/ingestion.md) · [RAG Quickstart](docs/getting-started/rag-quickstart.md).
 
-## Security ships with the framework
+## Security
 
-Most agent frameworks treat security as "add auth middleware when you get to production." InitRunner ships these controls in the box. Turn them on with config keys.
+Five controls ship with the framework and turn on via config keys. Roles without a `security:` section get safe defaults.
 
-**Agents accept untrusted input.** Content policy engine (blocked patterns, prompt length limits, optional LLM topic classifier) and an input guard capability validate prompts before the agent starts.
+**Input validation.** A content policy engine (blocked patterns, prompt length limits, optional LLM topic classifier) plus an input guard capability validate prompts before the agent starts.
 
-**Agents call tools with real consequences.** [InitGuard](https://github.com/initrunner/initguard) ABAC policy engine checks every tool call and delegation against CEL policies. Per-tool allow/deny glob patterns enforce argument-level permissions.
+**Tool authorization.** [InitGuard](https://github.com/initrunner/initguard) ABAC policy engine checks every tool call and delegation against CEL policies. Per-tool allow/deny glob patterns enforce argument-level permissions.
 
-**Agents run code.** PEP 578 audit-hook sandbox restricts filesystem writes, blocks subprocess spawning, blocks private-IP network access, and prevents dangerous imports. Docker container sandboxing adds read-only rootfs, memory/CPU limits, and network isolation on top.
+**Sandboxed code execution.** PEP 578 audit hooks block filesystem writes outside allowlisted paths, block `subprocess.Popen` and `os.system` by default, block `socket.connect` to private IPs, and always block `ctypes.dlopen` and new threads. Docker container sandboxing adds read-only rootfs, memory and CPU limits, and network isolation on top.
 
-**Everything is logged.** Append-only SQLite audit trail with automatic secret scrubbing. Regex patterns redact GitHub tokens, AWS keys, Stripe keys, and more from both prompts and outputs.
+**Tamper-evident audit trail.** Every run writes to an append-only SQLite audit log, HMAC-SHA256 signed over the previous record's hash. `initrunner audit verify-chain` detects any middle-row mutation, reorder, or deletion. Secrets are scrubbed on write.
 
-All of these are opt-in via the `security:` config key. Roles without a `security:` section get safe defaults.
+**Encrypted credential vault.** `initrunner vault init` creates `~/.initrunner/vault.enc`, encrypted with Fernet + scrypt from your passphrase. API keys resolve from env vars first, then the vault, so existing `api_key_env:` and `${VAR}` placeholders keep working.
 
-```bash
-export INITRUNNER_POLICY_DIR=./policies
-initrunner run role.yaml    # tool calls + delegation checked against policies
+```yaml
+spec:
+  security:
+    audit_hooks_enabled: true
+    block_private_ips: true
+    input_guard:
+      max_prompt_chars: 10000
+      blocked_patterns: ["(?i)rm -rf /"]
 ```
 
-See [Agent Policy](docs/security/agent-policy.md) · [Security](docs/security/security.md) · [Guardrails](docs/configuration/guardrails.md).
+See [Security](docs/security/security.md) · [Agent Policy](docs/security/agent-policy.md) · [Credential Vault](docs/security/vault.md) · [Audit Chain](docs/security/audit-chain.md) · [Guardrails](docs/configuration/guardrails.md).
 
 ## Cost control
 
-Most frameworks track token budgets. InitRunner also enforces USD cost budgets. Set a daily or weekly dollar cap on a daemon and it stops firing triggers when the threshold is hit.
+USD budgets cap daemon spend. Hit the cap and triggers stop firing until the window resets.
 
 ```yaml
 spec:
@@ -235,11 +227,11 @@ spec:
     daemon_weekly_cost_budget: 25.00  # USD per week
 ```
 
-Cost estimation uses [genai-prices](https://pypi.org/project/genai-prices/) to calculate actual spend per model and provider. Every run logs its cost to the audit trail. The dashboard shows cost analytics across agents and time ranges. See [Cost Tracking](docs/core/cost-tracking.md).
+Cost estimation uses [genai-prices](https://pypi.org/project/genai-prices/) to compute spend per model and provider. Every run logs its cost to the audit trail. The dashboard plots cost across agents and time ranges. See [Cost Tracking](docs/core/cost-tracking.md).
 
 ## Multi-agent orchestration
 
-Chain agents into flows. One agent's output feeds into the next. Sense routing auto-picks the right target per message using keyword scoring first (zero API calls), with an LLM tiebreak only when the keywords are ambiguous:
+Chain agents into flows. One agent's output feeds the next.
 
 ```yaml
 apiVersion: initrunner/v1
@@ -261,7 +253,9 @@ spec:
 initrunner flow up flow.yaml
 ```
 
-**Team mode** is for when you want multiple perspectives on one task without a full flow. Define personas in a single file with three strategies: sequential handoff, parallel execution, or debate (multi-round argumentation with synthesis). See [Patterns Guide](docs/orchestration/patterns-guide.md) · [Team Mode](docs/orchestration/team_mode.md) · [Flow](docs/orchestration/flow.md).
+Sense routing picks the right target per message using keyword scoring first (zero API calls); only ambiguous cases fall back to an LLM tiebreak.
+
+**Team mode** gives multiple perspectives on one task without a full flow. Define personas in one file with three strategies: sequential handoff, parallel execution, or debate (multi-round argumentation with synthesis). See [Patterns Guide](docs/orchestration/patterns-guide.md) · [Team Mode](docs/orchestration/team_mode.md) · [Flow](docs/orchestration/flow.md).
 
 ## MCP and interfaces
 
@@ -326,11 +320,6 @@ Built on [PydanticAI](https://ai.pydantic.dev/). See [CONTRIBUTING.md](CONTRIBUT
 
 **OCI registries:** Push role bundles to any OCI-compliant registry: `initrunner publish oci://ghcr.io/org/my-agent --tag 1.0.0`. See [OCI Distribution](docs/core/oci-distribution.md).
 
-**Cloud deploy:**
-
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/FROM_REPO?referralCode=...)
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/vladkesler/initrunner)
-
 ## Documentation
 
 | Area | Key docs |
@@ -343,7 +332,7 @@ Built on [PydanticAI](https://ai.pydantic.dev/). See [CONTRIBUTING.md](CONTRIBUT
 | Orchestration | [Patterns Guide](docs/orchestration/patterns-guide.md) · [Flow](docs/orchestration/flow.md) · [Delegation](docs/orchestration/delegation.md) · [Team Mode](docs/orchestration/team_mode.md) · [Triggers](docs/core/triggers.md) |
 | Interfaces | [Dashboard](docs/interfaces/dashboard.md) · [API Server](docs/interfaces/server.md) · [MCP Gateway](docs/interfaces/mcp-gateway.md) · [A2A](docs/interfaces/a2a.md) |
 | Distribution | [OCI Distribution](docs/core/oci-distribution.md) · [Shareable Templates](docs/getting-started/shareable-templates.md) |
-| Security | [Security Model](docs/security/security.md) · [Agent Policy](docs/security/agent-policy.md) · [Guardrails](docs/configuration/guardrails.md) |
+| Security | [Security Model](docs/security/security.md) · [Credential Vault](docs/security/vault.md) · [Audit Chain](docs/security/audit-chain.md) · [Agent Policy](docs/security/agent-policy.md) · [Guardrails](docs/configuration/guardrails.md) |
 | Operations | [Audit](docs/core/audit.md) · [Cost Tracking](docs/core/cost-tracking.md) · [Reports](docs/core/reports.md) · [Evals](docs/core/evals.md) · [Doctor](docs/operations/doctor.md) · [Observability](docs/core/observability.md) · [CI/CD](docs/operations/cicd.md) |
 
 ## Examples
@@ -370,4 +359,4 @@ Licensed under [MIT](LICENSE-MIT) or [Apache-2.0](LICENSE-APACHE), at your optio
 
 ---
 
-<p align="center"><sub>v2026.4.14</sub></p>
+<p align="center"><sub>v2026.4.15</sub></p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -25,20 +25,9 @@
   <a href="README.md">English</a> · 简体中文 · <a href="README.ja.md">日本語</a>
 </p>
 
-<p align="center">
-  <strong>2026.4.15 新功能</strong><br>
-  加密凭证保险库 · HMAC 签名审计链 · 双向 Slack 适配器 · 单字起始模板名 · <a href="CHANGELOG.md#202641515---2026-04-17">完整变更日志</a>
-</p>
-
 > **注意:** 这是社区翻译版本。以 [英文 README](README.md) 为准。翻译内容可能滞后于最新更新。
 
 用一个 YAML 文件定义 Agent。和它对话。效果满意后，让它自主运行。信任它之后，部署为守护进程，响应 cron 调度、文件变更、webhook 和 Telegram 消息。同一个文件，从原型到生产，无需重写。
-
-```bash
-initrunner run researcher -i                            # 和它对话
-initrunner run researcher -a -p "Audit this codebase"   # 让它自主工作
-initrunner run researcher --daemon                      # 7x24 运行，响应触发器
-```
 
 ## 快速开始
 
@@ -51,16 +40,18 @@ initrunner setup        # 向导：选择提供商、模型、API 密钥
 
 ### 入门模板
 
-运行 `initrunner run --list` 查看完整目录。模型根据你的 API 密钥自动检测。
+八个一条命令即可运行的入门模板。用 `initrunner run --list` 浏览完整目录。模型根据你的 API 密钥自动检测。
 
 | 入门模板 | 功能描述 |
 |---------|---------|
-| `helpdesk` | 导入你的文档，获得带引用和记忆的问答 Agent |
-| `scholar` | 3-Agent 流水线：规划者、网络研究员、综合者 |
-| `reviewer` | 多视角审查：架构师、安全专家、维护者 |
-| `reader` | 索引你的仓库，聊架构，跨会话学习模式 |
-| `writer` | 研究、撰写、编辑/事实核查，通过 webhook 或 cron 触发 |
+| `helpdesk` | 针对你的文档（Markdown、PDF、HTML、Word）的问答 Agent，带引用和按用户记忆 |
+| `scholar` | 三 Agent 研究团队：规划者、网络研究员、综合者，共享记忆 |
+| `reviewer` | 多视角代码审查：架构师、安全专家、维护者 |
+| `reader` | 索引代码库，聊架构，跨会话记忆模式 |
+| `scout` | 网络研究，产出带引用的结构化简报 |
+| `writer` | 主题到文章流水线：研究员、撰稿人、编辑/事实核查员，由 webhook 或 cron 驱动 |
 | `mail` | 监控收件箱，分类消息，起草回复，紧急邮件通知 Slack |
+| `librarian` | 带文档摄入的知识库问答 Agent |
 
 ### 创建自己的 Agent
 
@@ -108,17 +99,17 @@ spec:
 这个文件有四种用法：
 
 ```bash
-initrunner run reviewer.yaml -i              # 交互式 REPL
-initrunner run reviewer.yaml -p "Review PR #42"  # 一个提示，一个回复
-initrunner run reviewer.yaml -a -p "Audit the whole repo"  # 自主模式：规划、执行、反思
-initrunner run reviewer.yaml --daemon        # 持续运行，响应触发器
+initrunner run reviewer.yaml -i                          # 交互式 REPL
+initrunner run reviewer.yaml -p "Review PR #42"          # 一个提示，一个回复
+initrunner run reviewer.yaml -a -p "Audit the whole repo"  # 自主循环
+initrunner run reviewer.yaml --daemon                    # 由触发器驱动
 ```
 
 `model:` 部分是可选的。省略它，InitRunner 会根据你的 API 密钥自动检测。支持 Anthropic、OpenAI、Google、Groq、Mistral、Cohere、xAI、OpenRouter、Ollama 以及任何 OpenAI 兼容端点。
 
 ### 自主模式
 
-加上 `-a`，Agent 不再是聊天机器人。它建立任务列表，逐项完成，反思进度，全部做完后自动停止。四种推理策略控制思考方式：`react`（默认）、`todo_driven`、`plan_execute` 和 `reflexion`。
+加上 `-a`，Agent 建立任务列表，逐项处理，反思进度，全部完成后自动停止。四种推理策略控制思考方式：`react`（默认）、`todo_driven`、`plan_execute` 和 `reflexion`。
 
 ```yaml
 spec:
@@ -130,11 +121,11 @@ spec:
     autonomous_timeout_seconds: 600
 ```
 
-空转检测捕获循环不前进的 Agent。历史压缩总结旧上下文，防止长时间运行耗尽 Token 窗口。预算约束、迭代限制和墙钟超时确保一切有界。查看 [自主执行](docs/orchestration/autonomy.md) · [护栏](docs/configuration/guardrails.md)。
+空转检测捕获无进展的循环。历史压缩总结旧上下文，防止长时间运行耗尽 Token 窗口。迭代、Token 和墙钟上限约束每次运行。查看 [自主执行](docs/orchestration/autonomy.md) · [护栏](docs/configuration/guardrails.md)。
 
-### 守护进程模式
+### 守护进程
 
-添加触发器并切换到 `--daemon`。Agent 持续运行，响应事件。每个事件触发一次提示-响应循环。
+添加触发器并切换到 `--daemon`。Agent 持续运行。每个事件触发一次提示-响应循环。
 
 ```yaml
 spec:
@@ -149,21 +140,17 @@ spec:
       allowed_user_ids: [123456789]
 ```
 
-```bash
-initrunner run role.yaml --daemon   # 运行直到 Ctrl+C
-```
-
-六种触发器类型：cron、webhook、file_watch、heartbeat、telegram、discord。守护进程热重载角色变更无需重启，最多同时运行 4 个触发器。查看 [触发器](docs/core/triggers.md)。
+六种触发器类型：cron、webhook、file_watch、heartbeat、telegram、discord。守护进程热重载角色变更无需重启，最多同时运行四个触发器。查看 [触发器](docs/core/triggers.md)。
 
 ### 自动驾驶
 
-`--autopilot` 就是 `--daemon`，但每个触发器走完整的自主循环。有人给你的 Telegram 机器人发消息"帮我找从纽约到伦敦下周的航班"。在守护进程模式下，你只有一次回答机会。在自动驾驶模式下，Agent 搜索网络、比较选项、核对日期，然后发回有价值的答案。
+`--autopilot` 就是 `--daemon` 加上每个触发器的自主循环。Telegram 消息 "帮我找从纽约到伦敦下周的航班" 在守护进程模式下只有一次 LLM 轮次。在自动驾驶模式下，Agent 搜索航班、比较选项、核对日期，然后回复一份候选列表。
 
 ```bash
 initrunner run role.yaml --autopilot
 ```
 
-你也可以有选择性地设置。在单个触发器上设置 `autonomous: true`，其余保持单次响应：
+也可以有选择地启用。在单个触发器上设置 `autonomous: true`，其余保持单次响应：
 
 ```yaml
 spec:
@@ -177,16 +164,16 @@ spec:
     - type: file_watch
       paths: [./src]
       prompt_template: "File changed: {path}. Review it."
-      # 默认：快速单次响应
+      # 默认：单次响应
 ```
 
-### 记忆贯穿一切
+### 跨模式的记忆
 
-情景记忆、语义记忆和程序记忆在交互式会话、自主运行和守护进程触发之间持久化。每次会话结束后，整合过程使用 LLM 从对话中提取持久事实。Agent 不只是运行，它随时间积累知识。
+语义记忆（Agent 学到的事实）、情景记忆（过去会话中发生的事）和程序记忆（Agent 倾向的解决方式）在交互式会话、自主运行和守护进程触发之间持久化。每次会话后，LLM 将持久事实整合到存储中。知识随时间积累，不只是在单次运行内。
 
 ## 会学习的 Agent
 
-将你的 Agent 指向一个目录。它会自动提取、分块、嵌入并索引你的文档。对话过程中，Agent 自动搜索索引并引用找到的内容。新增和变更的文件每次运行时自动重新索引，无需人工干预。
+将 Agent 指向一个目录。它会自动提取、分块、嵌入并索引文档。对话时，Agent 搜索索引并引用找到的内容。新增和变更的文件每次运行时重新索引。
 
 ```yaml
 spec:
@@ -200,35 +187,40 @@ spec:
 
 ```bash
 cd ~/myproject
-initrunner run reader -i   # 索引你的代码，然后开始问答
+initrunner run reader -i   # 索引代码，然后开始问答
 ```
 
-关键在于整合。每次会话结束后，LLM 阅读发生了什么，并将其提炼到语义存储中。Agent 在周二调试会话中学到的事实，会在周四审查代码时出现。Flow 中的共享记忆让 Agent 团队共同积累知识。查看 [记忆](docs/core/memory.md) · [摄入](docs/core/ingestion.md) · [RAG 快速开始](docs/getting-started/rag-quickstart.md)。
+关键在于整合。每次会话结束后，LLM 阅读对话并将其提炼到语义存储中。Agent 在周二调试会话中学到的事实，会在周四审查代码时出现。Flow 中的共享记忆让 Agent 团队共同积累知识。查看 [记忆](docs/core/memory.md) · [摄入](docs/core/ingestion.md) · [RAG 快速开始](docs/getting-started/rag-quickstart.md)。
 
-## 安全是内置的
+## 安全
 
-大多数 Agent 框架把安全当作"到了生产再加认证中间件"。InitRunner 把这些控制开箱内置。用配置项启用即可。
+五个随框架内置、通过配置项启用的控制项。没有 `security:` 部分的角色使用安全默认值。
 
-**Agent 接受不可信输入。** 内容策略引擎（禁止模式、提示长度限制、可选的 LLM 话题分类器）和输入守卫能力在 Agent 启动前验证提示。
+**输入验证。** 内容策略引擎（禁止模式、提示长度限制、可选的 LLM 话题分类器）和输入守卫能力在 Agent 启动前验证提示。
 
-**Agent 调用有实际后果的工具。** [InitGuard](https://github.com/initrunner/initguard) ABAC 策略引擎根据 CEL 策略检查每次工具调用和委托。每个工具的 allow/deny glob 模式执行参数级权限。
+**工具授权。** [InitGuard](https://github.com/initrunner/initguard) ABAC 策略引擎根据 CEL 策略检查每次工具调用和委托。每个工具的 allow/deny glob 模式执行参数级权限。
 
-**Agent 执行代码。** PEP 578 审计钩子沙箱限制文件系统写入、阻止子进程、阻止私有 IP 网络访问、阻止危险导入。Docker 容器沙箱在此基础上增加只读根文件系统、内存/CPU 限制和网络隔离。
+**代码执行沙箱。** PEP 578 审计钩子阻止允许列表之外的文件系统写入，默认阻止 `subprocess.Popen` 和 `os.system`，阻止 `socket.connect` 到私有 IP，并始终阻止 `ctypes.dlopen` 和新线程。Docker 容器沙箱在此基础上增加只读根文件系统、内存/CPU 限制和网络隔离。
 
-**一切都有记录。** 仅追加 SQLite 审计日志，自动敏感信息清理。正则模式从提示和输出中脱敏 GitHub Token、AWS 密钥、Stripe 密钥等。
+**防篡改审计日志。** 每次运行写入仅追加的 SQLite 审计日志，用 HMAC-SHA256 对前一条记录的哈希进行签名。`initrunner audit verify-chain` 可检测任何中间记录的修改、重排或删除。敏感信息在写入时脱敏。
 
-所有这些都通过 `security:` 配置项启用。没有 `security:` 部分的角色会获得安全默认值。
+**加密凭证保险库。** `initrunner vault init` 创建 `~/.initrunner/vault.enc`，使用 Fernet + scrypt 根据你的口令加密。API 密钥先从环境变量解析，然后从保险库，所以现有的 `api_key_env:` 和 `${VAR}` 占位符继续工作。
 
-```bash
-export INITRUNNER_POLICY_DIR=./policies
-initrunner run role.yaml    # 工具调用 + 委托根据策略检查
+```yaml
+spec:
+  security:
+    audit_hooks_enabled: true
+    block_private_ips: true
+    input_guard:
+      max_prompt_chars: 10000
+      blocked_patterns: ["(?i)rm -rf /"]
 ```
 
-查看 [Agent 策略](docs/security/agent-policy.md) · [安全](docs/security/security.md) · [护栏](docs/configuration/guardrails.md)。
+查看 [安全](docs/security/security.md) · [Agent 策略](docs/security/agent-policy.md) · [凭证保险库](docs/security/vault.md) · [审计链](docs/security/audit-chain.md) · [护栏](docs/configuration/guardrails.md)。
 
 ## 成本控制
 
-大多数框架追踪 Token 预算。InitRunner 还强制执行 USD 成本预算。为守护进程设置每日或每周美元上限，达到阈值后停止触发。
+USD 预算限制守护进程支出。达到上限后，触发器停止发火，直到窗口重置。
 
 ```yaml
 spec:
@@ -237,11 +229,11 @@ spec:
     daemon_weekly_cost_budget: 25.00  # 每周 USD
 ```
 
-成本估算使用 [genai-prices](https://pypi.org/project/genai-prices/) 计算每个模型和提供商的实际支出。每次运行的成本记录到审计日志。仪表盘显示跨 Agent 和时间范围的成本分析。查看 [成本追踪](docs/core/cost-tracking.md)。
+成本估算使用 [genai-prices](https://pypi.org/project/genai-prices/) 按模型和提供商计算支出。每次运行的成本记录到审计日志。仪表盘绘制跨 Agent 和时间范围的成本曲线。查看 [成本追踪](docs/core/cost-tracking.md)。
 
 ## 多 Agent 编排
 
-将 Agent 串联为 Flow。一个 Agent 的输出传入下一个。智能路由先用关键词评分自动选择目标（零 API 调用），仅在关键词模糊时用 LLM 仲裁：
+将 Agent 串联为 Flow。一个 Agent 的输出传入下一个。
 
 ```yaml
 apiVersion: initrunner/v1
@@ -263,7 +255,9 @@ spec:
 initrunner flow up flow.yaml
 ```
 
-**团队模式** 适用于需要多视角处理同一任务但不需要完整 Flow 的场景。在一个文件中定义多个角色，三种策略：顺序交接、并行执行或辩论（多轮论证加综合）。查看 [模式指南](docs/orchestration/patterns-guide.md) · [团队模式](docs/orchestration/team_mode.md) · [Flow](docs/orchestration/flow.md)。
+智能路由先用关键词评分选择目标（零 API 调用），仅在关键词模糊时才用 LLM 仲裁。
+
+**团队模式** 适用于需要多视角处理同一任务、但不需要完整 Flow 的场景。在一个文件中定义多个角色，三种策略：顺序交接、并行执行或辩论（多轮论证加综合）。查看 [模式指南](docs/orchestration/patterns-guide.md) · [团队模式](docs/orchestration/team_mode.md) · [Flow](docs/orchestration/flow.md)。
 
 ## MCP 与界面
 
@@ -328,11 +322,6 @@ initrunner/
 
 **OCI 注册表:** 将角色包推送到任何 OCI 兼容注册表: `initrunner publish oci://ghcr.io/org/my-agent --tag 1.0.0`。查看 [OCI 分发](docs/core/oci-distribution.md)。
 
-**云部署:**
-
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/FROM_REPO?referralCode=...)
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/vladkesler/initrunner)
-
 ## 文档
 
 | 领域 | 关键文档 |
@@ -345,7 +334,7 @@ initrunner/
 | 编排 | [Patterns Guide](docs/orchestration/patterns-guide.md) · [Flow](docs/orchestration/flow.md) · [Delegation](docs/orchestration/delegation.md) · [Team Mode](docs/orchestration/team_mode.md) · [Triggers](docs/core/triggers.md) |
 | 界面 | [Dashboard](docs/interfaces/dashboard.md) · [API Server](docs/interfaces/server.md) · [MCP Gateway](docs/interfaces/mcp-gateway.md) · [A2A](docs/interfaces/a2a.md) |
 | 分发 | [OCI Distribution](docs/core/oci-distribution.md) · [Shareable Templates](docs/getting-started/shareable-templates.md) |
-| 安全 | [Security Model](docs/security/security.md) · [Agent Policy](docs/security/agent-policy.md) · [Guardrails](docs/configuration/guardrails.md) |
+| 安全 | [Security Model](docs/security/security.md) · [Credential Vault](docs/security/vault.md) · [Audit Chain](docs/security/audit-chain.md) · [Agent Policy](docs/security/agent-policy.md) · [Guardrails](docs/configuration/guardrails.md) |
 | 运维 | [Audit](docs/core/audit.md) · [Cost Tracking](docs/core/cost-tracking.md) · [Reports](docs/core/reports.md) · [Evals](docs/core/evals.md) · [Doctor](docs/operations/doctor.md) · [Observability](docs/core/observability.md) · [CI/CD](docs/operations/cicd.md) |
 
 ## 示例
@@ -357,7 +346,7 @@ initrunner examples copy code-reviewer # 复制到当前目录
 
 ## 升级
 
-运行 `initrunner doctor --role role.yaml` 检查角色文件的废弃字段、Schema 错误和规范版本问题。添加 `--fix` 自动修复。查看 [废弃说明](docs/operations/deprecations.md)。
+运行 `initrunner doctor --role role.yaml` 检查角色文件的废弃字段、Schema 错误和规范版本问题。添加 `--fix` 自动修复。用 `--flow flow.yaml` 验证整个 Flow 及其引用的角色。查看 [废弃说明](docs/operations/deprecations.md)。
 
 ## 社区
 
@@ -372,4 +361,4 @@ initrunner examples copy code-reviewer # 复制到当前目录
 
 ---
 
-<p align="center"><sub>v2026.4.12</sub></p>
+<p align="center"><sub>v2026.4.15</sub></p>


### PR DESCRIPTION
Rewrite READMEs (English, Chinese, Japanese) for clarity. Refresh stale content: current starter slugs, security section (adds vault + HMAC audit chain), footer version. Remove broken Cloud deploy block and What's new banner.

No code changes, no version bump.