### PR TITLE
feat: hardened Docker runtime support (gVisor / Kata)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,8 +120,9 @@ Detailed docs live in `docs/`. Key references:
 | A2A server (agent-to-agent) | `docs/interfaces/a2a.md` |
 | Testing guide | `docs/operations/testing.md` |
 | Runtime sandbox overview | `docs/security/sandbox.md` |
+| Sandbox backend comparison (microVM, gVisor, etc.) | `docs/security/sandbox-comparison.md` |
 | Bubblewrap sandbox (Linux, no daemon) | `docs/security/bubblewrap.md` |
-| Docker sandbox (cross-platform containers) | `docs/security/docker-sandbox.md` |
+| Docker sandbox (cross-platform containers, hardened runtimes) | `docs/security/docker-sandbox.md` |
 | Agent policy (initguard) | `docs/security/agent-policy.md` |
 | Auth & guardrails | `docs/security/auth.md`, `docs/configuration/guardrails.md` |
 | CI/CD & releases | `docs/operations/cicd.md`, `docs/operations/pypi_publish.md` |

--- a/docs/security/docker-sandbox.md
+++ b/docs/security/docker-sandbox.md
@@ -43,6 +43,7 @@ security:
       image: python:3.12-slim
       user: auto            # "auto" | "1000:1000" | null (root)
       extra_args: []        # dangerous flags blocked by schema
+      runtime: null         # null | runc | runsc | kata-runtime | kata-qemu | kata-fc | kata-clh
 ```
 
 ## Isolation model
@@ -108,15 +109,43 @@ Each becomes one `-e KEY=value` flag.
 
 ### `extra_args` validation
 
-`docker.extra_args` accepts additional `docker run` flags (e.g. `--ulimit=nofile=1024`). A blocklist rejects flags that defeat isolation:
+`docker.extra_args` accepts additional `docker run` flags (e.g. `--ulimit=nofile=1024`). A blocklist rejects flags that defeat isolation or override fields the schema owns:
 
 - `--privileged`
 - `--cap-add` (any form: bare, `--cap-add=NET_ADMIN`, `--cap-add NET_ADMIN`)
-- `--security-opt` when it disables seccomp/apparmor
-- `--pid=host`, `--ipc=host`, `--uts=host`, `--userns=host`
-- `--device`, `--volume-driver`, `--runtime`
+- `--security-opt`
+- `--pid=host`, `--ipc=host`, `--uts=host`, `--userns=host`, `--network=host`
+- `--device`, `--volume-driver`
+- `--runtime` (use the `docker.runtime` field instead, see below)
 
 See `initrunner/agent/schema/security.py` for the full `_DOCKER_BLOCKED_ARGS` set.
+
+### Hardened runtime (`docker.runtime`)
+
+The default Docker runtime (`runc`) shares the host kernel. For workloads where that's not an acceptable trust boundary, set `docker.runtime` to a stronger runtime:
+
+| Value | Isolation class | Notes |
+|---|---|---|
+| `null` (default) | Container (runc) | Standard namespaces + cgroups + seccomp. Shares the host kernel. |
+| `runc` | Container | Same as `null`, but pinned explicitly so preflight fails loud if runc is missing. |
+| `runsc` | Userspace kernel (gVisor) | Syscalls intercepted in userspace. Narrow attack surface. Not a microVM. |
+| `kata-runtime` | microVM (Kata, default hypervisor) | Real guest kernel inside a hypervisor. |
+| `kata-qemu` / `kata-fc` / `kata-clh` | microVM (Kata, named hypervisor) | Pin Kata to QEMU, Firecracker, or Cloud Hypervisor. |
+
+See [sandbox-comparison.md](sandbox-comparison.md) for an honest matrix across all backends.
+
+Preflight calls `docker info --format '{{json .Runtimes}}'` whenever `runtime` is set and raises `SandboxUnavailableError` with an install hint if the runtime isn't registered with the daemon. Confirm manually with:
+
+```bash
+docker info --format '{{json .Runtimes}}' | jq 'keys'
+```
+
+Install per upstream docs. Verified examples (correct as of 2026-05; check upstream before copying):
+
+- gVisor (Debian 12, x86_64): see https://gvisor.dev/docs/user_guide/install/. After installing the `runsc` binary, register it in `/etc/docker/daemon.json` (`{"runtimes": {"runsc": {"path": "/usr/local/bin/runsc"}}}`) and `systemctl restart docker`.
+- Kata Containers: see https://github.com/kata-containers/kata-containers/blob/main/docs/install/README.md. The package name and registration step vary by distro and hypervisor.
+
+Roles that depend on a hardened runtime should declare it in `metadata.tags` (e.g. `[hardened, gvisor]`) so consumers know the host requirement before they install.
 
 ## Container cleanup on timeout
 

--- a/docs/security/sandbox-comparison.md
+++ b/docs/security/sandbox-comparison.md
@@ -1,0 +1,87 @@
+# Sandbox Backend Comparison
+
+This page compares InitRunner's sandbox backends against the harder isolation primitives you can layer on top of the Docker backend. Use it to pick the right tradeoff for a given role, and to answer the "but does it support microVMs?" question without hand-waving.
+
+For the operational config reference, see [Runtime Sandbox](sandbox.md). For per-backend deep-dives, see [Bubblewrap](bubblewrap.md), [Docker](docker-sandbox.md), and [SSH](ssh-sandbox.md).
+
+## Isolation classes, not interchangeable
+
+The choices below are not all the same kind of thing. Three distinct isolation classes show up in this matrix:
+
+- **Container.** Shares the host kernel. Isolation comes from Linux namespaces, cgroups, seccomp, and capability dropping. This is `runc` (Docker's default) and `bwrap`.
+- **Userspace kernel.** A user-space process intercepts and reimplements the syscall surface. The host kernel is still underneath but the guest only touches it through a narrow, audited boundary. This is gVisor (`runsc`). It is **not** a microVM.
+- **microVM.** A real guest kernel runs inside a lightweight hypervisor. Container-like UX, VM-grade isolation, ~125ms cold start. This is Kata Containers (Firecracker, QEMU, or Cloud Hypervisor under the hood) and bare Firecracker.
+
+Calling everything "a sandbox" hides the part that matters. A vendor saying "we have microVMs" without naming the runtime usually means Kata or Firecracker; a vendor saying "we have gVisor sandboxes" is in a different (and weaker, but cheaper and faster) class.
+
+## Backends and runtimes at a glance
+
+| Backend / runtime | Class | Shares host kernel | Cold start | Linux only | Daemon | Native InitRunner support |
+|---|---|---|---|---|---|---|
+| `bwrap` | Container | yes | ~fork+exec | yes | no | first-class |
+| `docker` (runtime: `runc`) | Container | yes | ~200-500ms | no (also macOS, Windows) | yes (Docker) | first-class |
+| `docker` (runtime: `runsc`) | Userspace kernel | partial (syscall boundary) | ~250-700ms | yes | yes (Docker) | via `docker.runtime` |
+| `docker` (runtime: `kata-runtime` / `kata-qemu` / `kata-fc` / `kata-clh`) | microVM | no | ~100-300ms | yes | yes (Docker + Kata) | via `docker.runtime` |
+| Bare Firecracker | microVM | no | ~125ms | yes (KVM required) | none | not in v1 (see below) |
+| `ssh` | Remote execution, not isolation | n/a | network-bound | n/a | no | first-class for remote runs |
+
+A few things this matrix doesn't capture in cells:
+
+- **`runc` vs `bwrap` isolation strength is roughly equivalent at the kernel-attack-surface level.** They differ on operational shape (daemon vs no daemon, image vs host filesystem, cross-platform vs Linux-only), not on the size of the kernel they share with you.
+- **gVisor's cost isn't latency, it's compatibility.** Some syscalls aren't implemented; some are slower. Most general-purpose code runs fine; numerical kernels and io_uring-heavy workloads need testing.
+- **Kata's cost isn't latency either.** It's host setup. KVM, nested virt if you're already inside a VM, and a kernel image that works for your guest. On a clean Linux host it's an apt-get and a daemon restart; on a CI runner inside a VM it can be a multi-hour yak shave.
+- **Bare Firecracker is great for serverless platforms and a poor fit for "swap in for one tool call."** You own the rootfs, the jailer, the vsock plumbing, and the lifecycle. We'd take it on if a design partner needs daemon-free microVMs and accepts the cost; otherwise Kata-on-Docker covers the same threat model with code we already have.
+
+## Use X when...
+
+**Use `bwrap` when** you're on Linux, you don't have or want a Docker daemon, and the audit chain + ABAC layer above the sandbox is your real defense. This is the right default for most personal and CI use. Fast, no daemon, no image pulls.
+
+**Use plain Docker (`runc`) when** you need cross-platform (macOS or Windows dev hosts), pinned OS images, or bridge networking with a user-defined network. Same kernel-isolation strength as `bwrap`, different operational shape.
+
+**Use Docker + `runsc` (gVisor) when** you're running code you don't trust at the syscall level (LLM-generated shell, untrusted user-submitted scripts) but a microVM is overkill. Userspace kernel boundary, narrow attack surface, no hypervisor required. Compatible with most Python / Node / Go workloads. Test compatibility for native binaries with unusual syscall patterns.
+
+**Use Docker + Kata (microVM) when** the threat model says "this code may exploit a kernel CVE" and your enterprise security review wants a vendor checkbox that says "microVM." Real guest kernel, real hypervisor, container UX. Requires the host to be able to run a hypervisor.
+
+**Use bare Firecracker when** you're building a serverless agent platform that runs many short-lived microVMs, you want no Docker daemon in the loop, and you accept owning the rootfs / jailer / orchestration. Out of scope for InitRunner v1.
+
+**Use `ssh` when** you want code to run on a specific machine (a build server, a GPU box, a customer-owned environment), not for containment. SSH is *where*, not *how-isolated*.
+
+## Threat models we cover, and what each backend buys you
+
+| Concern | `bwrap` | Docker (`runc`) | Docker + `runsc` | Docker + Kata |
+|---|---|---|---|---|
+| Filesystem write outside sandbox | blocked | blocked | blocked | blocked |
+| Network egress (when `network: none`) | blocked (kernel) | blocked (kernel) | blocked (kernel) | blocked (kernel) |
+| Reading host home dir / SSH keys | blocked | blocked | blocked | blocked |
+| Resource exhaustion (fork bomb, OOM, runaway CPU) | systemd-run limits | cgroups | cgroups | cgroups |
+| Container escape via kernel CVE | host kernel exposed | host kernel exposed | userspace boundary in front | guest kernel + hypervisor in front |
+| Spectre-class side channels | host kernel exposed | host kernel exposed | partial mitigation | hypervisor boundary |
+| Confused-deputy via shared mounts | mitigated by `read_only_rootfs` and explicit `bind_mounts` | same | same | same |
+
+The rows where `bwrap` and Docker (`runc`) line up are the same kernel-attack-surface story. The interesting deltas are the bottom three rows, which is exactly what gVisor and Kata exist to address.
+
+## What InitRunner adds on top of any of these
+
+The sandbox is one layer. The rest of InitRunner's threat model lives outside the sandbox:
+
+- **HMAC-signed audit chain** ([audit-chain.md](audit-chain.md)) so post-incident review has tamper-evident records of what tools ran with what arguments.
+- **ABAC / capability gating** ([agent-policy.md](agent-policy.md)) so a compromised agent can't reach for a tool it was never granted.
+- **PEP 578 audit hook sandbox** ([security.md](security.md)) for custom Python tools that run in-process.
+- **SSRF guards** for web tools that run outside the sandbox.
+
+For most threat models, layering a real microVM under the same audit/ABAC/SSRF surface is the upgrade path; ripping out the audit chain to chase microVMs is the wrong trade.
+
+## How to verify what you've actually got
+
+```bash
+# Provider, daemon, and connectivity checks for a specific role:
+initrunner doctor --role path/to/role.yaml --deep
+
+# Schema validation plus a plain-language summary of the sandbox section:
+initrunner validate path/to/role.yaml --explain
+
+# For Docker: which runtimes are registered?
+docker info --format '{{json .Runtimes}}' | jq 'keys'
+```
+
+If a role's `security.sandbox.docker.runtime` isn't in that last list, preflight will fail with a remediation hint at agent startup. That's the loud failure we want; silent fallback to `runc` would be a security regression.

--- a/docs/security/sandbox.md
+++ b/docs/security/sandbox.md
@@ -5,10 +5,12 @@ Tool subprocesses run under kernel-level isolation, outside the initrunner proce
 Pick one of three backends:
 
 - **[Bubblewrap](bubblewrap.md)** — Linux user namespaces. No daemon, no Docker, no root. Default on Linux.
-- **[Docker](docker-sandbox.md)** — containers via the Docker daemon. Works on macOS, Windows, and Linux. Supports pinned images and bridge networking.
+- **[Docker](docker-sandbox.md)** — containers via the Docker daemon. Works on macOS, Windows, and Linux. Supports pinned images, bridge networking, and hardened runtimes (gVisor, Kata Containers) via `docker.runtime`.
 - **[SSH](ssh-sandbox.md)** — remote execution on an existing host via OpenSSH. Not a kernel sandbox; use for *where* code runs (a build server, a GPU box), not for *containing* untrusted code.
 
 `backend: auto` tries bwrap on Linux and falls back to Docker. SSH is opt-in only (`backend: ssh`) because it needs an explicit remote host. This page is the shared config reference; the linked pages cover each backend's details, examples, and limits.
+
+For an honest comparison across backends and isolation classes (container vs userspace kernel vs microVM), see [Sandbox Backend Comparison](sandbox-comparison.md).
 
 ## Configuration
 
@@ -69,12 +71,15 @@ The dedicated [bubblewrap](bubblewrap.md) and [Docker](docker-sandbox.md) pages 
 |---|---|---|
 | **Platform** | Linux only | macOS, Windows, Linux |
 | **Daemon** | None (`bwrap` binary) | Docker daemon required |
-| **Startup cost** | ~fork+execve | ~200–500ms per call |
+| **Startup cost** | ~fork+execve | ~200-500ms per call |
 | **Filesystem** | Host `/usr`, `/bin`, `/lib` bound read-only | Pinned image |
 | **Network isolation** | `--unshare-net` | `--network none` |
 | **Bridge networking** | Not supported | `--network bridge` |
 | **Resource limits** | `systemd-run --user` (skipped with warning if unavailable) | `-m`, `--cpus`, `--pids-limit` |
+| **Hardened runtime** | n/a | `docker.runtime: runsc / kata-runtime / kata-qemu / kata-fc / kata-clh` |
 | **Install** | `apt install bubblewrap` | `apt install docker.io` or Docker Desktop |
+
+For when a microVM checkbox is the actual question, see [Sandbox Backend Comparison](sandbox-comparison.md).
 
 ## Mount validation
 

--- a/examples/roles/docker-sandbox-hardened.yaml
+++ b/examples/roles/docker-sandbox-hardened.yaml
@@ -1,0 +1,42 @@
+apiVersion: initrunner/v1
+kind: Agent
+metadata:
+  name: docker-sandbox-hardened
+  description: Code execution agent with a hardened Docker runtime (gVisor by default). See docs/security/sandbox-comparison.md.
+  tags: [example, security, docker, hardened]
+  author: InitRunner Team
+  version: "1.0.0"
+spec:
+  role: |
+    You are a code execution assistant running inside Docker with a hardened
+    runtime. Syscalls are intercepted by gVisor (or your configured runtime),
+    so the host kernel attack surface is much smaller than a vanilla container.
+
+    Use the shell tool to run commands and the python tool to execute code.
+    Network is disabled and the rootfs is read-only.
+  model:
+    temperature: 0.1
+    max_tokens: 4096
+  tools:
+    - type: shell
+      require_confirmation: false
+      blocked_commands: []
+    - type: python
+      require_confirmation: false
+  security:
+    sandbox:
+      backend: docker
+      network: none
+      memory_limit: 256m
+      cpu_limit: 1.0
+      read_only_rootfs: true
+      docker:
+        image: python:3.12-slim
+        # Requires the runtime to be installed AND registered with Docker.
+        # Confirm with: docker info --format '{{json .Runtimes}}'
+        # Swap to kata-runtime / kata-qemu / kata-fc / kata-clh for a true microVM.
+        runtime: runsc
+  guardrails:
+    max_tokens_per_run: 30000
+    max_tool_calls: 15
+    timeout_seconds: 120

--- a/initrunner/agent/docker_sandbox.py
+++ b/initrunner/agent/docker_sandbox.py
@@ -126,6 +126,9 @@ def _build_docker_cmd(
     """Build the ``docker run --rm`` command prefix (without the final command)."""
     cmd = ["docker", "run", "--rm", "--init"]
 
+    if config.docker.runtime is not None:
+        cmd.extend(["--runtime", config.docker.runtime])
+
     if container_name:
         cmd.extend(["--name", container_name])
     cmd.extend(["--label", "initrunner.managed=true"])

--- a/initrunner/agent/runtime_sandbox/docker.py
+++ b/initrunner/agent/runtime_sandbox/docker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 import time
 from collections.abc import Mapping, Sequence
@@ -22,6 +23,49 @@ from initrunner.agent.runtime_sandbox.base import (
     SandboxUnavailableError,
 )
 from initrunner.agent.schema.security import BindMount, SandboxConfig
+
+_RUNTIME_INSTALL_HINTS: dict[str, str] = {
+    "runsc": (
+        "gVisor (runsc): install per https://gvisor.dev/docs/user_guide/install/, "
+        "register with Docker via /etc/docker/daemon.json, then restart the daemon."
+    ),
+    "kata-runtime": (
+        "Kata Containers: install per https://github.com/kata-containers/kata-containers/"
+        "blob/main/docs/install/README.md and register with Docker."
+    ),
+    "kata-qemu": "Kata Containers (QEMU hypervisor): install per the Kata install docs.",
+    "kata-fc": "Kata Containers (Firecracker hypervisor): install per the Kata install docs.",
+    "kata-clh": "Kata Containers (Cloud Hypervisor): install per the Kata install docs.",
+    "runc": "runc ships with Docker by default; an unregistered runc points to a broken install.",
+}
+
+
+def _list_registered_runtimes() -> list[str] | None:
+    """Return Docker's registered runtime names, or None if the query failed.
+
+    None means we couldn't determine the runtime list (transient docker info
+    failure, malformed JSON). Callers must treat that as "unknown" rather than
+    "empty list," so a transient hiccup never silently passes preflight.
+    """
+    try:
+        proc = subprocess.run(
+            ["docker", "info", "--format", "{{json .Runtimes}}"],
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+    if proc.returncode != 0:
+        return None
+    try:
+        data = json.loads(proc.stdout.decode("utf-8", errors="replace"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return [k for k in data.keys() if isinstance(k, str)]
+
 
 if TYPE_CHECKING:
     from initrunner.audit.logger import AuditLogger
@@ -62,6 +106,34 @@ class DockerBackend:
                     "  Fedora: dnf install docker && systemctl start docker"
                 ),
             )
+        runtime = self._config.docker.runtime
+        if runtime is not None:
+            registered = _list_registered_runtimes()
+            if registered is None:
+                raise SandboxUnavailableError(
+                    backend="docker",
+                    reason=(
+                        f"could not query Docker runtimes to verify '{runtime}' "
+                        "(docker info failed or returned malformed output)"
+                    ),
+                    remediation=(
+                        "Re-run after the Docker daemon stabilizes, or unset "
+                        "security.sandbox.docker.runtime to fall back to the default."
+                    ),
+                )
+            if runtime not in registered:
+                hint = _RUNTIME_INSTALL_HINTS.get(
+                    runtime, "Install the runtime and register it with Docker."
+                )
+                listed = ", ".join(sorted(registered)) or "(none)"
+                raise SandboxUnavailableError(
+                    backend="docker",
+                    reason=(
+                        f"runtime '{runtime}' is not registered with Docker. "
+                        f"Registered runtimes: {listed}"
+                    ),
+                    remediation=hint,
+                )
         ensure_image_available(self._config.docker.image)
 
     def run(

--- a/initrunner/agent/schema/security.py
+++ b/initrunner/agent/schema/security.py
@@ -246,6 +246,10 @@ _DOCKER_BLOCKED_ARGS = frozenset(
         "--userns=host",
         "--network=host",
         "--ipc=host",
+        "--uts=host",
+        "--device",
+        "--volume-driver",
+        "--runtime",
     }
 )
 
@@ -263,12 +267,16 @@ class BindMount(BaseModel):
         return v
 
 
+DockerRuntime = Literal["runc", "runsc", "kata-runtime", "kata-qemu", "kata-fc", "kata-clh"]
+
+
 class DockerBackendConfig(BaseModel):
     """Docker-specific settings nested under sandbox.docker."""
 
     image: str = "python:3.12-slim"
     user: Literal["auto"] | str | None = "auto"
     extra_args: list[str] = Field(default_factory=list)
+    runtime: DockerRuntime | None = None
 
     @field_validator("image")
     @classmethod

--- a/tests/test_docker_sandbox.py
+++ b/tests/test_docker_sandbox.py
@@ -806,3 +806,163 @@ class TestUserFlag:
     def test_default_user_is_auto(self):
         config = DockerBackendConfig()
         assert config.user == "auto"
+
+
+# ===========================================================================
+# Hardened runtime (gVisor / Kata / Firecracker via --runtime)
+# ===========================================================================
+
+
+class TestDockerRuntimeField:
+    def test_default_runtime_is_none(self):
+        config = DockerBackendConfig()
+        assert config.runtime is None
+
+    def test_runsc_accepted(self):
+        config = DockerBackendConfig(runtime="runsc")
+        assert config.runtime == "runsc"
+
+    def test_kata_variants_accepted(self):
+        for name in ("kata-runtime", "kata-qemu", "kata-fc", "kata-clh"):
+            config = DockerBackendConfig(runtime=name)
+            assert config.runtime == name
+
+    def test_runc_accepted(self):
+        config = DockerBackendConfig(runtime="runc")
+        assert config.runtime == "runc"
+
+    def test_unknown_runtime_rejected(self):
+        with pytest.raises(ValueError):
+            DockerBackendConfig(runtime="bogus")
+
+    def test_extra_args_runtime_equals_form_rejected(self):
+        with pytest.raises(ValueError, match="blocked for security"):
+            DockerBackendConfig(extra_args=["--runtime=runsc"])
+
+    def test_extra_args_runtime_space_form_rejected(self):
+        with pytest.raises(ValueError, match="blocked for security"):
+            DockerBackendConfig(extra_args=["--runtime", "runsc"])
+
+    def test_extra_args_drift_now_blocked(self):
+        for arg in ("--device", "--volume-driver", "--uts=host"):
+            with pytest.raises(ValueError, match="blocked for security"):
+                DockerBackendConfig(extra_args=[arg])
+
+
+class TestBuildDockerCmdRuntime:
+    def test_runtime_emitted_before_image(self):
+        from initrunner.agent.docker_sandbox import _build_docker_cmd
+
+        config = SandboxConfig(backend="docker", docker=DockerBackendConfig(runtime="runsc"))
+        cmd = _build_docker_cmd(config)
+        assert "--runtime" in cmd
+        rt_idx = cmd.index("--runtime")
+        assert cmd[rt_idx + 1] == "runsc"
+        img_idx = cmd.index("python:3.12-slim")
+        assert rt_idx < img_idx
+
+    def test_no_runtime_flag_when_unset(self):
+        from initrunner.agent.docker_sandbox import _build_docker_cmd
+
+        config = SandboxConfig(backend="docker")
+        cmd = _build_docker_cmd(config)
+        assert "--runtime" not in cmd
+
+    def test_runtime_passes_through_in_run(self, tmp_path):
+        from initrunner.agent.runtime_sandbox.docker import DockerBackend
+
+        config = SandboxConfig(backend="docker", docker=DockerBackendConfig(runtime="runsc"))
+        backend = DockerBackend(config)
+        mock_result = MagicMock(stdout=b"ok\n", stderr=b"", returncode=0)
+        with patch(
+            "initrunner.agent.runtime_sandbox.docker.subprocess.run", return_value=mock_result
+        ) as mock_run:
+            backend.run(["echo", "ok"], env={}, cwd=tmp_path, timeout=30)
+            cmd = mock_run.call_args[0][0]
+            assert "--runtime" in cmd
+            rt_idx = cmd.index("--runtime")
+            assert cmd[rt_idx + 1] == "runsc"
+
+
+class TestDockerPreflightRuntime:
+    def _runtimes_payload(self, names: list[str]) -> bytes:
+        import json
+
+        return json.dumps({n: {"path": n} for n in names}).encode()
+
+    def test_preflight_passes_when_runtime_registered(self):
+        from initrunner.agent.runtime_sandbox.docker import DockerBackend
+
+        config = SandboxConfig(backend="docker", docker=DockerBackendConfig(runtime="runsc"))
+        backend = DockerBackend(config)
+        info_proc = MagicMock(returncode=0, stdout=self._runtimes_payload(["runc", "runsc"]))
+        with patch(
+            "initrunner.agent.runtime_sandbox.docker.check_docker_available", return_value=True
+        ):
+            with patch(
+                "initrunner.agent.runtime_sandbox.docker.subprocess.run", return_value=info_proc
+            ):
+                with patch(
+                    "initrunner.agent.runtime_sandbox.docker.ensure_image_available"
+                ) as mock_ensure:
+                    backend.preflight()
+                    mock_ensure.assert_called_once_with("python:3.12-slim")
+
+    def test_preflight_fails_when_runtime_missing(self):
+        from initrunner.agent.runtime_sandbox.base import SandboxUnavailableError
+        from initrunner.agent.runtime_sandbox.docker import DockerBackend
+
+        config = SandboxConfig(backend="docker", docker=DockerBackendConfig(runtime="runsc"))
+        backend = DockerBackend(config)
+        info_proc = MagicMock(returncode=0, stdout=self._runtimes_payload(["runc"]))
+        with patch(
+            "initrunner.agent.runtime_sandbox.docker.check_docker_available", return_value=True
+        ):
+            with patch(
+                "initrunner.agent.runtime_sandbox.docker.subprocess.run", return_value=info_proc
+            ):
+                with patch(
+                    "initrunner.agent.runtime_sandbox.docker.ensure_image_available"
+                ) as mock_ensure:
+                    with pytest.raises(SandboxUnavailableError) as exc_info:
+                        backend.preflight()
+                    assert "runsc" in str(exc_info.value)
+                    assert "gVisor" in exc_info.value.remediation
+                    mock_ensure.assert_not_called()
+
+    def test_preflight_fails_cleanly_on_malformed_json(self):
+        from initrunner.agent.runtime_sandbox.base import SandboxUnavailableError
+        from initrunner.agent.runtime_sandbox.docker import DockerBackend
+
+        config = SandboxConfig(backend="docker", docker=DockerBackendConfig(runtime="runsc"))
+        backend = DockerBackend(config)
+        info_proc = MagicMock(returncode=0, stdout=b"not-json")
+        with patch(
+            "initrunner.agent.runtime_sandbox.docker.check_docker_available", return_value=True
+        ):
+            with patch(
+                "initrunner.agent.runtime_sandbox.docker.subprocess.run", return_value=info_proc
+            ):
+                with patch(
+                    "initrunner.agent.runtime_sandbox.docker.ensure_image_available"
+                ) as mock_ensure:
+                    with pytest.raises(SandboxUnavailableError) as exc_info:
+                        backend.preflight()
+                    assert "could not query Docker runtimes" in exc_info.value.reason
+                    mock_ensure.assert_not_called()
+
+    def test_preflight_skips_runtime_check_when_unset(self):
+        from initrunner.agent.runtime_sandbox.docker import DockerBackend
+
+        config = SandboxConfig(backend="docker")
+        backend = DockerBackend(config)
+        with patch(
+            "initrunner.agent.runtime_sandbox.docker.check_docker_available", return_value=True
+        ):
+            with patch("initrunner.agent.runtime_sandbox.docker.subprocess.run") as mock_subproc:
+                with patch(
+                    "initrunner.agent.runtime_sandbox.docker.ensure_image_available"
+                ) as mock_ensure:
+                    backend.preflight()
+                    mock_subproc.assert_not_called()
+                    mock_ensure.assert_called_once_with("python:3.12-slim")


### PR DESCRIPTION
## Summary

Adds opt-in support for hardened Docker runtimes so users can flip on gVisor or Kata Containers without InitRunner shipping a new daemon dependency. Closes the "but Docker has microVMs" gap that came up in competitive review against Docker Sandbox.

## What ships

- **New field** `security.sandbox.docker.runtime` accepting `runc | runsc | kata-runtime | kata-qemu | kata-fc | kata-clh`. When set, `_build_docker_cmd` emits `--runtime <name>` right after `--init`. When unset, default Docker behavior is unchanged.
- **Preflight verifies the runtime is registered** before any container work. Calls `docker info --format '{{json .Runtimes}}'` with defensive parsing (any failure mode returns ``None`` and triggers a clean ``SandboxUnavailableError``, never raw JSON noise). Per-runtime install hints point at upstream docs.
- **Preflight ordering** runs the runtime check **before** `ensure_image_available`, so a misconfigured runtime doesn't trigger a multi-GB image pull on a doomed run.
- **Schema/doc drift fix**: ``_DOCKER_BLOCKED_ARGS`` now actually blocks ``--runtime``, ``--device``, ``--volume-driver``, ``--uts=host``. ``docs/security/docker-sandbox.md`` already claimed these were blocked; now they are. With ``--runtime`` promoted to a first-class field, the schema is the single source of truth (``extra_args: [--runtime, runsc]`` and ``[--runtime=runsc]`` are both rejected).
- **New comparison page** ``docs/security/sandbox-comparison.md`` distinguishes three isolation classes (container / userspace kernel / microVM) and gives an honest "use X when..." matrix. Linked from ``sandbox.md`` and the docs index.
- **Example role** ``examples/roles/docker-sandbox-hardened.yaml`` with ``runtime: runsc``.

## Test plan

- [x] Unit: 15 new tests in ``tests/test_docker_sandbox.py`` covering schema accept/reject, both ``extra_args`` forms (``--runtime=runsc`` and ``--runtime runsc``), the previously-orphan blocked args (``--device``, ``--volume-driver``, ``--uts=host``), command-builder positioning, runtime present/absent, preflight pass / fail / malformed-JSON, ordering against ``ensure_image_available``. All 85 tests in the file pass.
- [x] Lint: ``uv run ruff check .`` and ``uv run ruff format --check .`` clean.
- [x] Types: ``uv run ty check`` clean on changed source files.
- [x] CLI: ``initrunner validate examples/roles/docker-sandbox-hardened.yaml`` passes.
- [x] CLI negative: schema rejects bogus runtime; blocklist rejects both ``extra_args`` forms with a clear error.
- [x] CLI preflight: ``initrunner doctor --role examples/roles/docker-sandbox-hardened.yaml --deep`` on a host without gVisor reports ``sandbox docker fail`` with the registered-runtimes list and the gVisor install URL.
- [x] CLI preflight pass: ``runtime: runc`` (registered on this host) shows ``sandbox docker ok``.
- [x] Real docker run with ``runtime: runc`` against ``python:3.12-slim`` returns rc=0 in ~280ms, with ``--runtime runc`` injected at index 4 of the command.

## Explicitly not in this PR

- No native Firecracker backend (large effort; Kata-on-Docker covers the same threat model with code we already have).
- No OpenSandbox integration (it's a daemon wrapping primitives Docker exposes via ``--runtime``; redundant here).
- Web tools (``http``, ``web_reader``, ``web_scraper``) are still in-process. Real gap, separate plan.
- Sandboxes are still per-tool-call rather than per-agent-run. Real gap, separate plan.

## Release

Per the user's instruction, **do not release with this PR**. Merge as a feature, version bump comes later.