### PR TITLE
docs: surface the five core CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ initrunner setup        # wizard: pick provider, model, API key
 
 Or: `uv pip install "initrunner[recommended]"` / `pipx install "initrunner[recommended]"`. See [Installation](docs/getting-started/installation.md).
 
+New to InitRunner? Start with [the five commands you'll actually use](docs/getting-started/cli.md#five-commands-youll-actually-use).
+
 ### Starters
 
 Eight starters you can run in one command. Browse the full catalog with `initrunner run --list`. The model is auto-detected from your API key.

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -1,5 +1,15 @@
 # CLI Reference
 
+## Five commands you'll actually use
+
+> Most days, this is the whole CLI. Everything below exists for when you need it.
+>
+> - `initrunner new`: create a new agent role via conversational builder
+> - `initrunner run`: run an agent from a YAML file, starter name, or ephemeral mode
+> - `initrunner setup`: guided setup wizard for first-time configuration
+> - `initrunner doctor`: check provider configuration, API keys, and connectivity
+> - `initrunner install`: install a role from InitHub or an OCI registry
+
 ## Path resolution
 
 All commands that accept a role path also accept a **directory** or an **installed role name**. Resolution order:
@@ -13,7 +23,7 @@ All commands that accept a role path also accept a **directory** or an **install
 
 This means `initrunner run .` works from inside an agent directory, and `initrunner run code-reviewer` works after `initrunner install alice/code-reviewer`.
 
-## Commands
+## The full surface area, when you need it
 
 | Command | Description |
 |---------|-------------|


### PR DESCRIPTION
## Summary

- Add a "Five commands you'll actually use" callout at the top of `docs/getting-started/cli.md`, listing `initrunner new` / `run` / `setup` / `doctor` / `install` with one-liners pulled from each command's `--help`.
- Rename the existing `## Commands` heading to `## The full surface area, when you need it`. The 57-row table beneath it is unchanged.
- Link the new callout from the README quickstart so newcomers land on it directly.

## Why

`cli.md` lists 50+ top-level commands in one flat table at the same visual weight. New users can't tell which five they actually need on day one versus the long tail (`flow events`, `audit prune`, etc.). The depth was reading as a hazard ("look how much there is") instead of a benefit ("we have it when you need it"). Promoting the five and reframing the rest as "when you need it" fixes that without losing any reference content.

## Test plan

- [ ] Render `docs/getting-started/cli.md` on GitHub: callout appears as a left-bordered blockquote directly under `# CLI Reference`, with five bulleted commands.
- [ ] "The full surface area, when you need it" heading sits above the unchanged 57-row table.
- [ ] Click the README's "five commands you'll actually use" link: scrolls to the new section.
- [ ] Spot-check command one-liners against `initrunner <cmd> --help` output (descriptions are taken verbatim from there).