### PR TITLE
refactor: async-first executor, drop sync orchestration skeletons

### DIFF
--- a/initrunner/agent/executor.py
+++ b/initrunner/agent/executor.py
@@ -27,6 +27,7 @@ from pydantic_ai.exceptions import ModelHTTPError, UsageLimitExceeded
 from pydantic_ai.models import Model
 from pydantic_ai.models.fallback import FallbackExceptionGroup
 
+from initrunner._async import run_sync
 from initrunner._ids import generate_id
 from initrunner.agent.capabilities.content_guard import ContentBlockedError
 from initrunner.agent.prompt import UserPrompt
@@ -57,9 +58,9 @@ from .executor_output import (
     _validate_input_or_fail,
 )
 from .executor_retry import (
-    _retry_model_call,
+    _retry_model_call,  # noqa: F401
     _retry_model_call_async,
-    _run_with_timeout,
+    _run_with_timeout,  # noqa: F401
     _should_retry,  # noqa: F401
 )
 
@@ -143,85 +144,8 @@ def _prepare_run(
 
 
 # ---------------------------------------------------------------------------
-# Shared orchestration skeletons
+# Shared async orchestration skeleton
 # ---------------------------------------------------------------------------
-
-
-def _execute_orchestrated(
-    invoke_fn: Callable[[dict, RunResult], list],
-    on_error: Callable[[RunResult, Exception], None],
-    role: RoleDefinition,
-    prompt: UserPrompt,
-    *,
-    audit_logger: AuditLogger | None = None,
-    message_history: list | None = None,
-    model_override: Model | str | None = None,
-    trigger_type: str | None = None,
-    trigger_metadata: dict[str, str] | None = None,
-    extra_toolsets: list | None = None,
-    skip_input_validation: bool = False,
-    principal_id: str | None = None,
-) -> tuple[RunResult, list]:
-    """Sync execution skeleton shared by ``execute_run`` and ``execute_run_stream``.
-
-    *invoke_fn(run_kwargs, result) -> new_messages* performs the variant-specific
-    agent call and output processing.  *on_error(result, exc)* handles recoverable
-    errors (may set ``partial_output`` etc.).
-    """
-    agent_token = _enter_agent_context(role)
-    try:
-        run_id, _usage_limits, run_kwargs, blocked = _prepare_run(
-            role,
-            prompt,
-            audit_logger=audit_logger,
-            message_history=message_history,
-            model_override=model_override,
-            trigger_type=trigger_type,
-            trigger_metadata=trigger_metadata,
-            extra_toolsets=extra_toolsets,
-            skip_input_validation=skip_input_validation,
-            principal_id=principal_id,
-        )
-        if blocked is not None:
-            return blocked, []
-
-        result = RunResult(run_id=run_id)
-        new_messages: list = []
-        start = time.monotonic()
-
-        with _create_run_span(run_id, role, trigger_type) as span:
-            try:
-                new_messages = invoke_fn(run_kwargs, result)
-            except ContentBlockedError as e:
-                result.success = False
-                result.error = e.reason
-                result.error_category = ErrorCategory.CONTENT_BLOCKED
-            except (
-                ModelHTTPError,
-                UsageLimitExceeded,
-                ConnectionError,
-                TimeoutError,
-                OSError,
-                FallbackExceptionGroup,
-            ) as e:
-                on_error(result, e)
-
-            result.duration_ms = int((time.monotonic() - start) * 1000)
-            _record_span_metrics(span, result)
-
-        _audit_result(
-            result,
-            role,
-            prompt,
-            audit_logger=audit_logger,
-            trigger_type=trigger_type,
-            trigger_metadata=trigger_metadata,
-            principal_id=principal_id,
-        )
-
-        return result, new_messages
-    finally:
-        _exit_agent_context(agent_token)
 
 
 async def _execute_orchestrated_async(
@@ -315,28 +239,21 @@ def execute_run(
     skip_input_validation: bool = False,
     principal_id: str | None = None,
 ) -> tuple[RunResult, list]:
-    """Execute a single agent run, returning the result and updated message history."""
-
-    def invoke(run_kwargs: dict, result: RunResult) -> list:
-        agent_result = _run_with_timeout(
-            lambda: _retry_model_call(lambda: agent.run_sync(prompt, **run_kwargs)),
-            timeout=role.spec.guardrails.timeout_seconds,
+    """Sync wrapper around ``execute_run_async`` (owns the event loop)."""
+    return run_sync(
+        execute_run_async(
+            agent,
+            role,
+            prompt,
+            audit_logger=audit_logger,
+            message_history=message_history,
+            model_override=model_override,
+            trigger_type=trigger_type,
+            trigger_metadata=trigger_metadata,
+            extra_toolsets=extra_toolsets,
+            skip_input_validation=skip_input_validation,
+            principal_id=principal_id,
         )
-        return _process_agent_output(agent_result, result, role)
-
-    return _execute_orchestrated(
-        invoke,
-        _handle_run_error,
-        role,
-        prompt,
-        audit_logger=audit_logger,
-        message_history=message_history,
-        model_override=model_override,
-        trigger_type=trigger_type,
-        trigger_metadata=trigger_metadata,
-        extra_toolsets=extra_toolsets,
-        skip_input_validation=skip_input_validation,
-        principal_id=principal_id,
     )
 
 
@@ -351,7 +268,7 @@ def _resume_prompt(approvals: dict[str, bool]) -> UserPrompt:
     return f"(resume: {decisions})"
 
 
-def execute_run_resume(
+async def _execute_resume_async_inner(
     agent: Agent,
     role: RoleDefinition,
     *,
@@ -362,79 +279,7 @@ def execute_run_resume(
     model_override: Model | str | None = None,
     principal_id: str | None = None,
 ) -> tuple[RunResult, list]:
-    """Resume a paused run by supplying approvals for pending tool calls.
-
-    Unlike ``execute_run`` this does not take a new prompt — the model
-    already produced one, the user just answered the approval question.
-    On re-pause (the model queues more approval-required calls after
-    executing the approved ones) the returned ``RunResult`` has
-    ``status="paused"`` again with a fresh ``pending_approvals`` list.
-    """
-    from pydantic_ai import DeferredToolResults
-
-    agent_token = _enter_agent_context(role)
-    try:
-        result = RunResult(run_id=run_id)
-        start = time.monotonic()
-        deferred = DeferredToolResults(approvals=dict(approvals))
-        run_kwargs: dict[str, Any] = {
-            "message_history": message_history,
-            "deferred_tool_results": deferred,
-            "model": model_override,
-            "metadata": {"input_validated": True},
-        }
-        new_messages: list = []
-        timeout = role.spec.guardrails.timeout_seconds
-
-        with _create_run_span(run_id, role, trigger_type="resume") as span:
-            try:
-                agent_result = _run_with_timeout(
-                    lambda: _retry_model_call(lambda: agent.run_sync(**run_kwargs)),
-                    timeout=timeout,
-                )
-                new_messages = _process_agent_output(agent_result, result, role)
-            except ContentBlockedError as e:
-                result.success = False
-                result.error = e.reason
-                result.error_category = ErrorCategory.CONTENT_BLOCKED
-            except (
-                ModelHTTPError,
-                UsageLimitExceeded,
-                ConnectionError,
-                TimeoutError,
-                OSError,
-                FallbackExceptionGroup,
-            ) as e:
-                _handle_run_error(result, e, timeout_seconds=timeout)
-
-            result.duration_ms = int((time.monotonic() - start) * 1000)
-            _record_span_metrics(span, result)
-
-        _audit_result(
-            result,
-            role,
-            _resume_prompt(approvals),
-            audit_logger=audit_logger,
-            trigger_type="resume",
-            principal_id=principal_id,
-        )
-        return result, new_messages
-    finally:
-        _exit_agent_context(agent_token)
-
-
-async def execute_run_resume_async(
-    agent: Agent,
-    role: RoleDefinition,
-    *,
-    run_id: str,
-    message_history: list,
-    approvals: dict[str, bool],
-    audit_logger: AuditLogger | None = None,
-    model_override: Model | str | None = None,
-    principal_id: str | None = None,
-) -> tuple[RunResult, list]:
-    """Async variant of ``execute_run_resume``."""
+    """Shared async body for ``execute_run_resume`` and ``execute_run_resume_async``."""
     from pydantic_ai import DeferredToolResults
 
     agent_token = _enter_agent_context(role)
@@ -488,6 +333,63 @@ async def execute_run_resume_async(
         _exit_agent_context(agent_token)
 
 
+def execute_run_resume(
+    agent: Agent,
+    role: RoleDefinition,
+    *,
+    run_id: str,
+    message_history: list,
+    approvals: dict[str, bool],
+    audit_logger: AuditLogger | None = None,
+    model_override: Model | str | None = None,
+    principal_id: str | None = None,
+) -> tuple[RunResult, list]:
+    """Resume a paused run by supplying approvals for pending tool calls.
+
+    Unlike ``execute_run`` this does not take a new prompt — the model
+    already produced one, the user just answered the approval question.
+    On re-pause (the model queues more approval-required calls after
+    executing the approved ones) the returned ``RunResult`` has
+    ``status="paused"`` again with a fresh ``pending_approvals`` list.
+    """
+    return run_sync(
+        _execute_resume_async_inner(
+            agent,
+            role,
+            run_id=run_id,
+            message_history=message_history,
+            approvals=approvals,
+            audit_logger=audit_logger,
+            model_override=model_override,
+            principal_id=principal_id,
+        )
+    )
+
+
+async def execute_run_resume_async(
+    agent: Agent,
+    role: RoleDefinition,
+    *,
+    run_id: str,
+    message_history: list,
+    approvals: dict[str, bool],
+    audit_logger: AuditLogger | None = None,
+    model_override: Model | str | None = None,
+    principal_id: str | None = None,
+) -> tuple[RunResult, list]:
+    """Async variant of ``execute_run_resume``."""
+    return await _execute_resume_async_inner(
+        agent,
+        role,
+        run_id=run_id,
+        message_history=message_history,
+        approvals=approvals,
+        audit_logger=audit_logger,
+        model_override=model_override,
+        principal_id=principal_id,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Streaming execution
 # ---------------------------------------------------------------------------
@@ -509,63 +411,23 @@ def execute_run_stream(
     skip_input_validation: bool = False,
     principal_id: str | None = None,
 ) -> tuple[RunResult, list]:
-    """Execute a streaming agent run with guardrails, audit, and stream callbacks.
-
-    For text output roles, ``on_token(delta)`` fires per text delta.
-    For structured output roles (``output.type != "text"``), ``on_partial(partial)``
-    fires per progressively-validated partial output from
-    ``stream_output()``. Finalization routes through ``_finalize_run_output``
-    so deferred approvals, BaseModel serialization, and output validation
-    behave identically to non-streaming runs.
-    """
-    is_structured = role.spec.output.type != "text"
-    output_parts: list[str] = []
-
-    def invoke(run_kwargs: dict, result: RunResult) -> list:
-        stream_state: dict = {"messages": [], "usage": None, "output": None}
-
-        def _do_stream():
-            stream = agent.run_stream_sync(prompt, **run_kwargs)
-            if is_structured:
-                for partial in stream.stream_output(debounce_by=0.05):
-                    if on_partial is not None:
-                        on_partial(partial)
-            else:
-                for chunk in stream.stream_text(delta=True):
-                    output_parts.append(chunk)
-                    if on_token is not None:
-                        on_token(chunk)
-            stream_state["messages"] = stream.all_messages()
-            stream_state["usage"] = stream.usage()
-            stream_state["output"] = stream.get_output()
-
-        _run_with_timeout(
-            lambda: _retry_model_call(_do_stream, on_retry=output_parts.clear),
-            timeout=role.spec.guardrails.timeout_seconds,
-        )
-        new_messages = stream_state["messages"]
-        _finalize_run_output(
-            stream_state["output"],
-            stream_state["usage"],
-            new_messages,
-            result,
+    """Sync wrapper around ``execute_run_stream_async`` (owns the event loop)."""
+    return run_sync(
+        execute_run_stream_async(
+            agent,
             role,
+            prompt,
+            audit_logger=audit_logger,
+            message_history=message_history,
+            model_override=model_override,
+            on_token=on_token,
+            on_partial=on_partial,
+            extra_toolsets=extra_toolsets,
+            trigger_type=trigger_type,
+            trigger_metadata=trigger_metadata,
+            skip_input_validation=skip_input_validation,
+            principal_id=principal_id,
         )
-        return new_messages
-
-    return _execute_orchestrated(
-        invoke,
-        lambda r, e: _handle_run_error(r, e, partial_output="".join(output_parts)),
-        role,
-        prompt,
-        audit_logger=audit_logger,
-        message_history=message_history,
-        model_override=model_override,
-        trigger_type=trigger_type,
-        trigger_metadata=trigger_metadata,
-        extra_toolsets=extra_toolsets,
-        skip_input_validation=skip_input_validation,
-        principal_id=principal_id,
     )
 
 

--- a/initrunner/agent/loader.py
+++ b/initrunner/agent/loader.py
@@ -483,8 +483,6 @@ def build_agent(
     role_dir: Path | None = None,
     output_type: Any = None,
     extra_skill_dirs: list[Path] | None = None,
-    *,
-    prefer_async: bool = False,
 ) -> Agent:
     """Construct a PydanticAI Agent from a validated RoleDefinition."""
     # Ensure spec.model is a concrete ModelConfig (not PartialModelConfig)
@@ -530,7 +528,7 @@ def build_agent(
 
     from initrunner.agent.tools import build_toolsets
 
-    toolsets = build_toolsets(all_tools, role, role_dir=role_dir, prefer_async=prefer_async)
+    toolsets = build_toolsets(all_tools, role, role_dir=role_dir)
 
     capabilities = _build_capabilities(role)
 

--- a/initrunner/agent/tools/_registry.py
+++ b/initrunner/agent/tools/_registry.py
@@ -38,7 +38,6 @@ class ToolBuildContext:
 
     role: RoleDefinition
     role_dir: Path | None = None
-    prefer_async: bool = False
     sandbox_backend: Any = field(default=None)
 
     def __post_init__(self) -> None:

--- a/initrunner/agent/tools/http.py
+++ b/initrunner/agent/tools/http.py
@@ -6,39 +6,11 @@ import httpx
 from pydantic_ai.toolsets.function import FunctionToolset
 
 from initrunner.agent._truncate import truncate_output
-from initrunner.agent._urls import AsyncSSRFSafeTransport, SSRFBlocked, SSRFSafeTransport
+from initrunner.agent._urls import AsyncSSRFSafeTransport, SSRFBlocked
 from initrunner.agent.schema.tools import HttpToolConfig
 from initrunner.agent.tools._registry import ToolBuildContext, register_tool
 
 _MAX_HTTP_RESPONSE_BYTES = 102_400  # 100 KB
-
-
-def _do_http_request(
-    method: str,
-    path: str,
-    body: str,
-    base_url: str,
-    headers: dict[str, str],
-    allowed_methods: set[str],
-) -> str:
-    """Execute a sync HTTP request, returning a formatted response or error."""
-    method = method.upper()
-    if method not in allowed_methods:
-        return f"Error: HTTP method {method} is not allowed"
-    url = f"{base_url.rstrip('/')}/{path.lstrip('/')}"
-    try:
-        with httpx.Client(
-            headers=headers,
-            timeout=30,
-            transport=SSRFSafeTransport(),
-        ) as client:
-            resp = client.request(method, url, content=body if body else None)
-            text = truncate_output(resp.text, _MAX_HTTP_RESPONSE_BYTES)
-            return f"HTTP {resp.status_code}\n{text}"
-    except SSRFBlocked as e:
-        return str(e)
-    except httpx.HTTPError as e:
-        return f"HTTP error: {e}"
 
 
 async def _do_http_request_async(
@@ -76,22 +48,11 @@ def build_http_toolset(config: HttpToolConfig, ctx: ToolBuildContext) -> Functio
 
     toolset = FunctionToolset()
 
-    if ctx.prefer_async:
-
-        @toolset.tool_plain
-        async def http_request(method: str, path: str, body: str = "") -> str:
-            """Make an HTTP request to the configured base URL."""
-            return await _do_http_request_async(
-                method, path, body, config.base_url, config.headers, allowed_methods
-            )
-
-    else:
-
-        @toolset.tool_plain
-        def http_request(method: str, path: str, body: str = "") -> str:
-            """Make an HTTP request to the configured base URL."""
-            return _do_http_request(
-                method, path, body, config.base_url, config.headers, allowed_methods
-            )
+    @toolset.tool_plain
+    async def http_request(method: str, path: str, body: str = "") -> str:
+        """Make an HTTP request to the configured base URL."""
+        return await _do_http_request_async(
+            method, path, body, config.base_url, config.headers, allowed_methods
+        )
 
     return toolset

--- a/initrunner/agent/tools/image_gen.py
+++ b/initrunner/agent/tools/image_gen.py
@@ -45,23 +45,6 @@ def _openai_kwargs(prompt: str, size: str, quality: str, style: str, model: str)
     return kwargs
 
 
-def _generate_openai(
-    prompt: str,
-    size: str,
-    quality: str,
-    style: str,
-    model: str,
-    api_key: str,
-    timeout: int,
-) -> bytes:
-    """Generate an image via OpenAI DALL-E API, return raw PNG bytes."""
-    from openai import OpenAI  # type: ignore[import-not-found]
-
-    client = OpenAI(api_key=api_key, timeout=timeout)
-    response = client.images.generate(**_openai_kwargs(prompt, size, quality, style, model))
-    return base64.b64decode(response.data[0].b64_json)
-
-
 async def _generate_openai_async(
     prompt: str,
     size: str,
@@ -98,27 +81,6 @@ def _stability_extract(data: dict) -> bytes:
     if not artifacts:
         raise RuntimeError("Stability API returned no artifacts")
     return base64.b64decode(artifacts[0]["base64"])
-
-
-def _generate_stability(
-    prompt: str,
-    size: str,
-    api_key: str,
-    timeout: int,
-    model: str,
-) -> bytes:
-    """Generate an image via Stability AI REST API, return raw PNG bytes."""
-    import httpx
-
-    url, body = _stability_request_params(prompt, size, model)
-    with httpx.Client(timeout=timeout) as client:
-        resp = client.post(
-            url,
-            json=body,
-            headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
-        )
-        resp.raise_for_status()
-        return _stability_extract(resp.json())
 
 
 async def _generate_stability_async(
@@ -168,31 +130,6 @@ def _resolve_output_dir(config_dir: str) -> Path:
 # ---------------------------------------------------------------------------
 # Core functions
 # ---------------------------------------------------------------------------
-
-
-def _do_generate(
-    prompt: str,
-    size: str,
-    quality: str,
-    style: str,
-    provider: str,
-    model: str,
-    api_key: str,
-    timeout: int,
-    output_dir: Path,
-) -> str:
-    """Generate an image and save it. Returns the file path or an error."""
-    try:
-        if provider == "openai":
-            image_bytes = _generate_openai(prompt, size, quality, style, model, api_key, timeout)
-        elif provider == "stability":
-            image_bytes = _generate_stability(prompt, size, api_key, timeout, model)
-        else:
-            return f"Error: unknown provider: {provider}"
-    except Exception as exc:
-        return f"Error: image generation failed: {exc}"
-
-    return _save_image(image_bytes, output_dir)
 
 
 async def _do_generate_async(
@@ -284,114 +221,54 @@ def build_image_gen_toolset(
 
     toolset = FunctionToolset()
 
-    if ctx.prefer_async:
+    @toolset.tool_plain
+    async def generate_image(
+        prompt: str,
+        size: str = "",
+        style: str = "",
+        quality: str = "",
+    ) -> str:
+        """Generate an image from a text prompt and save it to disk.
 
-        @toolset.tool_plain
-        async def generate_image(
-            prompt: str,
-            size: str = "",
-            style: str = "",
-            quality: str = "",
-        ) -> str:
-            """Generate an image from a text prompt and save it to disk.
+        Returns the file path of the generated image.
 
-            Returns the file path of the generated image.
+        Args:
+            prompt: Description of the image to generate.
+            size: Image dimensions (e.g. "1024x1024"). Empty for default.
+            style: Style preset (e.g. "natural", "vivid"). Empty for default.
+            quality: Quality level (e.g. "standard", "hd"). Empty for default.
+        """
+        return await _do_generate_async(
+            prompt,
+            size or config.default_size,
+            quality or config.default_quality,
+            style or config.default_style,
+            config.provider,
+            config.model,
+            api_key,
+            config.timeout_seconds,
+            output_dir,
+        )
 
-            Args:
-                prompt: Description of the image to generate.
-                size: Image dimensions (e.g. "1024x1024"). Empty for default.
-                style: Style preset (e.g. "natural", "vivid"). Empty for default.
-                quality: Quality level (e.g. "standard", "hd"). Empty for default.
-            """
-            return await _do_generate_async(
-                prompt,
-                size or config.default_size,
-                quality or config.default_quality,
-                style or config.default_style,
-                config.provider,
-                config.model,
-                api_key,
-                config.timeout_seconds,
-                output_dir,
-            )
+    @toolset.tool_plain
+    async def edit_image(
+        image_path: str,
+        prompt: str,
+        size: str = "",
+    ) -> str:
+        """Edit an existing image using a text prompt (OpenAI only).
 
-        @toolset.tool_plain
-        async def edit_image(
-            image_path: str,
-            prompt: str,
-            size: str = "",
-        ) -> str:
-            """Edit an existing image using a text prompt (OpenAI only).
+        Returns the file path of the edited image.
 
-            Returns the file path of the edited image.
-
-            Args:
-                image_path: Path to the source image file.
-                prompt: Description of the desired edit.
-                size: Output dimensions. Empty for default.
-            """
-            loop = asyncio.get_running_loop()
-            return await loop.run_in_executor(
-                None,
-                lambda: _do_edit(
-                    image_path,
-                    prompt,
-                    size or config.default_size,
-                    config.model,
-                    api_key,
-                    config.timeout_seconds,
-                    output_dir,
-                    allowed_roots,
-                ),
-            )
-
-    else:
-
-        @toolset.tool_plain
-        def generate_image(
-            prompt: str,
-            size: str = "",
-            style: str = "",
-            quality: str = "",
-        ) -> str:
-            """Generate an image from a text prompt and save it to disk.
-
-            Returns the file path of the generated image.
-
-            Args:
-                prompt: Description of the image to generate.
-                size: Image dimensions (e.g. "1024x1024"). Empty for default.
-                style: Style preset (e.g. "natural", "vivid"). Empty for default.
-                quality: Quality level (e.g. "standard", "hd"). Empty for default.
-            """
-            return _do_generate(
-                prompt,
-                size or config.default_size,
-                quality or config.default_quality,
-                style or config.default_style,
-                config.provider,
-                config.model,
-                api_key,
-                config.timeout_seconds,
-                output_dir,
-            )
-
-        @toolset.tool_plain
-        def edit_image(
-            image_path: str,
-            prompt: str,
-            size: str = "",
-        ) -> str:
-            """Edit an existing image using a text prompt (OpenAI only).
-
-            Returns the file path of the edited image.
-
-            Args:
-                image_path: Path to the source image file.
-                prompt: Description of the desired edit.
-                size: Output dimensions. Empty for default.
-            """
-            return _do_edit(
+        Args:
+            image_path: Path to the source image file.
+            prompt: Description of the desired edit.
+            size: Output dimensions. Empty for default.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            lambda: _do_edit(
                 image_path,
                 prompt,
                 size or config.default_size,
@@ -400,6 +277,7 @@ def build_image_gen_toolset(
                 config.timeout_seconds,
                 output_dir,
                 allowed_roots,
-            )
+            ),
+        )
 
     return toolset

--- a/initrunner/agent/tools/registry.py
+++ b/initrunner/agent/tools/registry.py
@@ -83,8 +83,6 @@ def build_toolsets(
     tools: list[ToolConfig],
     role: RoleDefinition,
     role_dir: Path | None = None,
-    *,
-    prefer_async: bool = False,
 ) -> list[AbstractToolset]:
     """Build a list of PydanticAI toolsets from tool configs + optional retrieval."""
     from initrunner.agent.tool_events import wrap_observable
@@ -95,9 +93,7 @@ def build_toolsets(
     backend = resolve_backend(
         role.spec.security.sandbox, role_dir=role_dir, agent_name=role.metadata.name
     )
-    ctx = ToolBuildContext(
-        role=role, role_dir=role_dir, prefer_async=prefer_async, sandbox_backend=backend
-    )
+    ctx = ToolBuildContext(role=role, role_dir=role_dir, sandbox_backend=backend)
     agent_name = role.metadata.name
 
     install_audit_hooks(role)

--- a/initrunner/agent/tools/search.py
+++ b/initrunner/agent/tools/search.py
@@ -315,86 +315,43 @@ def build_search_toolset(
 
     toolset = FunctionToolset()
 
-    if ctx.prefer_async:
+    @toolset.tool_plain
+    async def web_search(query: str, num_results: int = 5) -> str:
+        """Search the web for information.
 
-        @toolset.tool_plain
-        async def web_search(query: str, num_results: int = 5) -> str:
-            """Search the web for information.
+        Args:
+            query: The search query string.
+            num_results: Maximum number of results to return (default 5).
+        """
+        return await _do_search_async(
+            query,
+            num_results,
+            config.max_results,
+            config.safe_search,
+            api_key,
+            config.timeout_seconds,
+            provider_fn,
+        )
 
-            Args:
-                query: The search query string.
-                num_results: Maximum number of results to return (default 5).
-            """
-            return await _do_search_async(
-                query,
-                num_results,
-                config.max_results,
-                config.safe_search,
-                api_key,
-                config.timeout_seconds,
-                provider_fn,
-            )
+    @toolset.tool_plain
+    async def news_search(query: str, num_results: int = 5, days_back: int = 7) -> str:
+        """Search for recent news articles.
 
-        @toolset.tool_plain
-        async def news_search(query: str, num_results: int = 5, days_back: int = 7) -> str:
-            """Search for recent news articles.
-
-            Args:
-                query: The search query string.
-                num_results: Maximum number of results to return (default 5).
-                days_back: How many days back to search (default 7).
-            """
-            return await _do_search_async(
-                query,
-                num_results,
-                config.max_results,
-                config.safe_search,
-                api_key,
-                config.timeout_seconds,
-                provider_fn,
-                news=True,
-                days_back=days_back,
-            )
-
-    else:
-
-        @toolset.tool_plain
-        def web_search(query: str, num_results: int = 5) -> str:
-            """Search the web for information.
-
-            Args:
-                query: The search query string.
-                num_results: Maximum number of results to return (default 5).
-            """
-            return _do_search(
-                query,
-                num_results,
-                config.max_results,
-                config.safe_search,
-                api_key,
-                config.timeout_seconds,
-                provider_fn,
-            )
-
-        @toolset.tool_plain
-        def news_search(query: str, num_results: int = 5, days_back: int = 7) -> str:
-            """Search for recent news articles.
-
-            Args:
-                query: The search query string.
-                num_results: Maximum number of results to return (default 5).
-                days_back: How many days back to search (default 7).
-            """
-            return _do_search(
-                query,
-                num_results,
-                config.max_results,
-                config.safe_search,
-                api_key,
-                config.timeout_seconds,
-                provider_fn,
-                news=True,
-                days_back=days_back,
-            )
+        Args:
+            query: The search query string.
+            num_results: Maximum number of results to return (default 5).
+            days_back: How many days back to search (default 7).
+        """
+        return await _do_search_async(
+            query,
+            num_results,
+            config.max_results,
+            config.safe_search,
+            api_key,
+            config.timeout_seconds,
+            provider_fn,
+            news=True,
+            days_back=days_back,
+        )
 
     return toolset

--- a/initrunner/agent/tools/web_reader.py
+++ b/initrunner/agent/tools/web_reader.py
@@ -9,26 +9,6 @@ from initrunner.agent.schema.tools import WebReaderToolConfig
 from initrunner.agent.tools._registry import ToolBuildContext, register_tool
 
 
-def _fetch_page_sync(url: str, config: WebReaderToolConfig) -> str:
-    """Fetch a page synchronously, returning markdown or an error string."""
-    error = check_domain_filter(url, config.allowed_domains, config.blocked_domains)
-    if error:
-        return error
-    try:
-        from initrunner._html import fetch_url_as_markdown
-
-        return fetch_url_as_markdown(
-            url,
-            timeout=config.timeout_seconds,
-            user_agent=config.user_agent,
-            max_bytes=config.max_content_bytes,
-        )
-    except SSRFBlocked as e:
-        return str(e)
-    except Exception as e:
-        return f"Error fetching URL: {e}"
-
-
 async def _fetch_page_async(url: str, config: WebReaderToolConfig) -> str:
     """Fetch a page asynchronously, returning markdown or an error string."""
     error = check_domain_filter(url, config.allowed_domains, config.blocked_domains)
@@ -54,18 +34,9 @@ def build_web_reader_toolset(config: WebReaderToolConfig, ctx: ToolBuildContext)
     """Build a FunctionToolset for fetching and reading web pages."""
     toolset = FunctionToolset()
 
-    if ctx.prefer_async:
-
-        @toolset.tool_plain
-        async def fetch_page(url: str) -> str:
-            """Fetch a web page and return its content as markdown."""
-            return await _fetch_page_async(url, config)
-
-    else:
-
-        @toolset.tool_plain
-        def fetch_page(url: str) -> str:
-            """Fetch a web page and return its content as markdown."""
-            return _fetch_page_sync(url, config)
+    @toolset.tool_plain
+    async def fetch_page(url: str) -> str:
+        """Fetch a web page and return its content as markdown."""
+        return await _fetch_page_async(url, config)
 
     return toolset

--- a/initrunner/agent/tools/web_scraper.py
+++ b/initrunner/agent/tools/web_scraper.py
@@ -8,12 +8,10 @@ from datetime import UTC, datetime
 
 from pydantic_ai.toolsets.function import FunctionToolset
 
-from initrunner._html import fetch_url_as_markdown
 from initrunner.agent._urls import SSRFBlocked, check_domain_filter
 from initrunner.agent.schema.tools import WebScraperToolConfig
 from initrunner.agent.tools._registry import ToolBuildContext, register_tool
 from initrunner.ingestion.chunker import chunk_text
-from initrunner.ingestion.embeddings import embed_single as _embed_single
 from initrunner.stores.base import make_store_config
 from initrunner.stores.factory import create_document_store
 
@@ -38,40 +36,6 @@ def _store_chunks(
             last_modified=time.time(),
         )
     return f"Stored {len(chunk_texts)} chunks from {url}"
-
-
-def _fetch_and_chunk(url, config, store_config):
-    """Domain-check, fetch (sync), and chunk. Returns (chunk_texts, markdown) or error str."""
-    error = check_domain_filter(url, config.allowed_domains, config.blocked_domains)
-    if error:
-        return error
-
-    try:
-        markdown = fetch_url_as_markdown(
-            url,
-            timeout=config.timeout_seconds,
-            user_agent=config.user_agent,
-            max_bytes=config.max_content_bytes,
-        )
-    except SSRFBlocked as e:
-        return str(e)
-    except Exception as e:
-        return f"Error fetching URL: {e}"
-
-    if not markdown.strip():
-        return f"No content extracted from {url}"
-
-    chunks = chunk_text(
-        markdown,
-        source=url,
-        strategy=store_config.chunking_strategy,
-        chunk_size=store_config.chunk_size,
-        chunk_overlap=store_config.chunk_overlap,
-    )
-    if not chunks:
-        return f"No chunks extracted from {url}"
-
-    return [c.text for c in chunks], markdown
 
 
 async def _fetch_and_chunk_async(url, config, store_config):
@@ -126,59 +90,25 @@ def build_web_scraper_toolset(
 
     toolset = FunctionToolset()
 
-    if ctx.prefer_async:
+    @toolset.tool_plain
+    async def scrape_page(url: str) -> str:
+        """Fetch a web page, extract its content, and store it in the document store.
 
-        @toolset.tool_plain
-        async def scrape_page(url: str) -> str:
-            """Fetch a web page, extract its content, and store it in the document store.
+        The content becomes immediately searchable via search_documents.
 
-            The content becomes immediately searchable via search_documents.
+        Args:
+            url: The URL to scrape and store.
+        """
+        result = await _fetch_and_chunk_async(url, config, store_config)
+        if isinstance(result, str):
+            return result
+        chunk_texts, markdown = result
 
-            Args:
-                url: The URL to scrape and store.
-            """
-            result = await _fetch_and_chunk_async(url, config, store_config)
-            if isinstance(result, str):
-                return result
-            chunk_texts, markdown = result
+        from initrunner.ingestion.embeddings import embed_single_async
 
-            from initrunner.ingestion.embeddings import embed_single_async
-
-            embeddings = await asyncio.gather(
-                *(
-                    embed_single_async(
-                        store_config.embed_provider,
-                        store_config.embed_model,
-                        ct,
-                        base_url=store_config.embed_base_url,
-                        api_key_env=store_config.embed_api_key_env,
-                        input_type="document",
-                    )
-                    for ct in chunk_texts
-                )
-            )
-
-            stored = _store_chunks(store_config, url, chunk_texts, list(embeddings))
-            return f"{stored} ({len(markdown):,} chars)"
-
-    else:
-
-        @toolset.tool_plain
-        def scrape_page(url: str) -> str:
-            """Fetch a web page, extract its content, and store it in the document store.
-
-            The content becomes immediately searchable via search_documents.
-
-            Args:
-                url: The URL to scrape and store.
-            """
-            result = _fetch_and_chunk(url, config, store_config)
-            if isinstance(result, str):
-                return result
-            chunk_texts, markdown = result
-
-            embeddings = [
-                _embed_single(
+        embeddings = await asyncio.gather(
+            *(
+                embed_single_async(
                     store_config.embed_provider,
                     store_config.embed_model,
                     ct,
@@ -187,9 +117,10 @@ def build_web_scraper_toolset(
                     input_type="document",
                 )
                 for ct in chunk_texts
-            ]
+            )
+        )
 
-            stored = _store_chunks(store_config, url, chunk_texts, embeddings)
-            return f"{stored} ({len(markdown):,} chars)"
+        stored = _store_chunks(store_config, url, chunk_texts, list(embeddings))
+        return f"{stored} ({len(markdown):,} chars)"
 
     return toolset

--- a/tests/test_eval_runner.py
+++ b/tests/test_eval_runner.py
@@ -2,7 +2,7 @@
 
 import json
 import textwrap
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydantic_ai import Agent
@@ -49,7 +49,7 @@ def _make_mock_agent(output: str = "Hello!"):
     usage.tool_calls = 0
     result.usage.return_value = usage
     result.all_messages.return_value = []
-    agent.run_sync.return_value = result
+    agent.run = AsyncMock(return_value=result)
     return agent
 
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,6 +1,6 @@
 """Tests for the executor."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -42,8 +42,39 @@ def _make_mock_agent(output: str = "Hello!", tokens_in: int = 10, tokens_out: in
     result.usage.return_value = usage
     result.all_messages.return_value = [{"role": "user", "content": "hi"}]
 
-    agent.run_sync.return_value = result
+    agent.run = AsyncMock(return_value=result)
     return agent
+
+
+class _AsyncIter:
+    """Minimal async iterator over a list of items."""
+
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+def _attach_stream_mock(agent: MagicMock, *, text=None, output="Hello", messages=None) -> None:
+    """Wire ``agent.run_stream`` as an async context manager yielding *text* deltas."""
+    stream = MagicMock()
+    stream.stream_text = MagicMock(return_value=_AsyncIter(text or ["Hello"]))
+    stream.stream_output = MagicMock(return_value=_AsyncIter([output]))
+    stream.all_messages = MagicMock(return_value=messages or [])
+    usage = MagicMock(input_tokens=5, output_tokens=3, total_tokens=8, tool_calls=0)
+    stream.usage = MagicMock(return_value=usage)
+    stream.get_output = AsyncMock(return_value=output)
+
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=stream)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    agent.run_stream = MagicMock(return_value=ctx)
 
 
 class TestShouldRetry:
@@ -204,7 +235,7 @@ class TestExecuteRun:
 
     def test_failed_run(self):
         agent = MagicMock()
-        agent.run_sync.side_effect = ConnectionError("API error")
+        agent.run = AsyncMock(side_effect=ConnectionError("API error"))
         role = _make_role()
 
         result, messages = execute_run(agent, role, "Hello")
@@ -224,12 +255,14 @@ class TestExecuteRun:
         from initrunner.agent.executor_models import ErrorCategory
 
         agent = MagicMock()
-        agent.run_sync.side_effect = FallbackExceptionGroup(
-            "all failed",
-            [
-                ModelHTTPError(status_code=500, model_name="anthropic:x", body=b""),
-                ModelHTTPError(status_code=401, model_name="openai:y", body=b""),
-            ],
+        agent.run = AsyncMock(
+            side_effect=FallbackExceptionGroup(
+                "all failed",
+                [
+                    ModelHTTPError(status_code=500, model_name="anthropic:x", body=b""),
+                    ModelHTTPError(status_code=401, model_name="openai:y", body=b""),
+                ],
+            )
         )
         role = _make_role()
         db_path = tmp_path / "audit.db"
@@ -278,8 +311,8 @@ class TestExecuteRun:
         history = [{"role": "user", "content": "previous"}]
 
         execute_run(agent, role, "Hello", message_history=history)
-        agent.run_sync.assert_called_once()
-        call_kwargs = agent.run_sync.call_args
+        agent.run.assert_called_once()
+        call_kwargs = agent.run.call_args
         assert call_kwargs.kwargs["message_history"] == history
 
     def test_trigger_context_flows_to_audit(self, tmp_path):
@@ -319,7 +352,7 @@ class TestExecuteRun:
         usage.tool_calls = 0
         result_mock.usage.return_value = usage
         result_mock.all_messages.return_value = []
-        agent.run_sync.return_value = result_mock
+        agent.run = AsyncMock(return_value=result_mock)
         role = _make_role()
 
         result, _ = execute_run(agent, role, "Hello")
@@ -341,7 +374,7 @@ class TestExecuteRun:
         usage.tool_calls = 0
         result_mock.usage.return_value = usage
         result_mock.all_messages.return_value = []
-        agent.run_sync.return_value = result_mock
+        agent.run = AsyncMock(return_value=result_mock)
         role = _make_role()
 
         result, _ = execute_run(agent, role, "Hello")
@@ -391,7 +424,7 @@ class TestExecuteRun:
         )
 
         execute_run(agent, role, "Hello")
-        call_kwargs = agent.run_sync.call_args
+        call_kwargs = agent.run.call_args
         limits = call_kwargs.kwargs["usage_limits"]
 
         assert limits.output_tokens_limit == 30000
@@ -406,7 +439,7 @@ class TestExecuteRun:
         role = _make_role()
 
         execute_run(agent, role, "Hello")
-        call_kwargs = agent.run_sync.call_args
+        call_kwargs = agent.run.call_args
         limits = call_kwargs.kwargs["usage_limits"]
 
         assert limits.output_tokens_limit == 50000
@@ -485,18 +518,7 @@ class TestSkipInputValidation:
         from unittest.mock import patch
 
         agent = MagicMock()
-        stream_ctx = MagicMock()
-        stream_mock = MagicMock()
-        stream_mock.stream_text.return_value = iter(["Hello"])
-        stream_mock.all_messages.return_value = []
-        usage = MagicMock()
-        usage.input_tokens = 5
-        usage.output_tokens = 3
-        usage.total_tokens = 8
-        stream_mock.usage.return_value = usage
-        stream_ctx.__enter__ = MagicMock(return_value=stream_mock)
-        stream_ctx.__exit__ = MagicMock(return_value=False)
-        agent.run_stream_sync.return_value = stream_ctx
+        _attach_stream_mock(agent)
 
         role = _make_role()
 
@@ -512,7 +534,7 @@ class TestContentBlockedError:
         from initrunner.agent.capabilities.content_guard import ContentBlockedError
 
         agent = MagicMock()
-        agent.run_sync.side_effect = ContentBlockedError("Input matches blocked pattern")
+        agent.run = AsyncMock(side_effect=ContentBlockedError("Input matches blocked pattern"))
         role = _make_role()
 
         result, messages = execute_run(agent, role, "Hello")
@@ -525,7 +547,7 @@ class TestContentBlockedError:
         from initrunner.agent.capabilities.content_guard import ContentBlockedError
 
         agent = MagicMock()
-        agent.run_stream_sync.side_effect = ContentBlockedError("Blocked")
+        agent.run_stream = MagicMock(side_effect=ContentBlockedError("Blocked"))
         role = _make_role()
 
         result, messages = execute_run_stream(agent, role, "Hello")
@@ -541,7 +563,7 @@ class TestContentBlockedError:
 
         db_path = tmp_path / "test_audit.db"
         agent = MagicMock()
-        agent.run_sync.side_effect = ContentBlockedError("Blocked by policy")
+        agent.run = AsyncMock(side_effect=ContentBlockedError("Blocked by policy"))
         role = _make_role()
 
         with AuditLogger(db_path) as logger:
@@ -564,7 +586,7 @@ class TestRunMetadata:
 
         execute_run(agent, role, "Hello", skip_input_validation=True)
 
-        meta = agent.run_sync.call_args.kwargs.get("metadata")
+        meta = agent.run.call_args.kwargs.get("metadata")
         assert meta is not None
         assert meta["input_validated"] is True
         assert meta["initrunner.agent_name"] == role.metadata.name
@@ -577,7 +599,7 @@ class TestRunMetadata:
 
         execute_run(agent, role, "Hello", skip_input_validation=False)
 
-        meta = agent.run_sync.call_args.kwargs.get("metadata")
+        meta = agent.run.call_args.kwargs.get("metadata")
         assert meta is not None
         assert meta["input_validated"] is True
         assert meta["initrunner.agent_name"] == role.metadata.name
@@ -589,6 +611,6 @@ class TestRunMetadata:
 
         execute_run(agent, role, "Hello", trigger_type="cron")
 
-        meta = agent.run_sync.call_args.kwargs.get("metadata")
+        meta = agent.run.call_args.kwargs.get("metadata")
         assert meta is not None
         assert meta["initrunner.trigger_type"] == "cron"

--- a/tests/test_executor_async.py
+++ b/tests/test_executor_async.py
@@ -246,29 +246,3 @@ class TestExecuteRunStreamAsync:
     # Streaming with structured output is now supported.
     # See tests/test_executor_streaming.py::TestAsyncStreamingEvents for the
     # full coverage (typed events, on_event callback, run_stream_events path).
-
-
-class TestToolBuildAsync:
-    def test_prefer_async_in_context(self):
-        from initrunner.agent.tools._registry import ToolBuildContext
-
-        role = _make_role()
-        ctx = ToolBuildContext(role=role, prefer_async=True)
-        assert ctx.prefer_async is True
-
-        ctx2 = ToolBuildContext(role=role)
-        assert ctx2.prefer_async is False
-
-    def test_build_toolsets_passes_prefer_async(self):
-        from initrunner.agent.tools._registry import ToolBuildContext
-        from initrunner.agent.tools.registry import build_toolsets
-
-        role = _make_role()
-
-        with patch("initrunner.agent.tools.registry.ToolBuildContext") as MockCtx:
-            MockCtx.return_value = ToolBuildContext(role=role, prefer_async=True)
-            build_toolsets([], role, prefer_async=True)
-            call = MockCtx.call_args
-            assert call.kwargs["role"] is role
-            assert call.kwargs["role_dir"] is None
-            assert call.kwargs["prefer_async"] is True

--- a/tests/test_executor_streaming.py
+++ b/tests/test_executor_streaming.py
@@ -12,10 +12,33 @@ Covers:
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import BaseModel
+
+
+class _AsyncIter:
+    """Minimal async iterator over a list of items."""
+
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+def _async_ctx(stream):
+    """Wrap *stream* in an async context manager mock."""
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=stream)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return ctx
 
 
 def _make_text_role():
@@ -134,15 +157,16 @@ class TestSyncStreamingStructured:
         final = _Sample(status="done", count=5)
 
         stream = MagicMock()
-        stream.stream_output = MagicMock(return_value=iter([partial_1, partial_2]))
+        stream.stream_output = MagicMock(return_value=_AsyncIter([partial_1, partial_2]))
+        stream.stream_text = MagicMock(return_value=_AsyncIter([]))
         stream.all_messages = MagicMock(return_value=[])
         stream.usage = MagicMock(
             return_value=MagicMock(input_tokens=3, output_tokens=4, total_tokens=7, tool_calls=0)
         )
-        stream.get_output = MagicMock(return_value=final)
+        stream.get_output = AsyncMock(return_value=final)
 
         agent = MagicMock()
-        agent.run_stream_sync = MagicMock(return_value=stream)
+        agent.run_stream = MagicMock(return_value=_async_ctx(stream))
 
         with patch("initrunner.agent.executor._prepare_run") as mock_prep:
             mock_prep.return_value = ("run-id", MagicMock(), {}, None)
@@ -171,15 +195,16 @@ class TestSyncStreamingStructured:
         tokens_seen: list[str] = []
 
         stream = MagicMock()
-        stream.stream_text = MagicMock(return_value=iter(["Hello ", "world"]))
+        stream.stream_text = MagicMock(return_value=_AsyncIter(["Hello ", "world"]))
+        stream.stream_output = MagicMock(return_value=_AsyncIter([]))
         stream.all_messages = MagicMock(return_value=[])
         stream.usage = MagicMock(
             return_value=MagicMock(input_tokens=1, output_tokens=2, total_tokens=3, tool_calls=0)
         )
-        stream.get_output = MagicMock(return_value="Hello world")
+        stream.get_output = AsyncMock(return_value="Hello world")
 
         agent = MagicMock()
-        agent.run_stream_sync = MagicMock(return_value=stream)
+        agent.run_stream = MagicMock(return_value=_async_ctx(stream))
 
         with patch("initrunner.agent.executor._prepare_run") as mock_prep:
             mock_prep.return_value = ("run-id", MagicMock(), {}, None)

--- a/tests/test_image_gen_tools.py
+++ b/tests/test_image_gen_tools.py
@@ -14,7 +14,7 @@ from initrunner.agent.tools.image_gen import (
 )
 
 
-def _make_ctx(prefer_async: bool = False):
+def _make_ctx():
     from initrunner.agent.schema.role import RoleDefinition
 
     role = RoleDefinition.model_validate(
@@ -28,7 +28,7 @@ def _make_ctx(prefer_async: bool = False):
             },
         }
     )
-    return ToolBuildContext(role=role, prefer_async=prefer_async)
+    return ToolBuildContext(role=role)
 
 
 # ---------------------------------------------------------------------------
@@ -100,26 +100,19 @@ class TestSaveImage:
 
 class TestGenerateImage:
     def test_openai_generate(self, tmp_path: Path):
-        fake_b64 = "aGVsbG8="  # base64 of "hello"
-        mock_response = MagicMock()
-        mock_response.data = [MagicMock(b64_json=fake_b64)]
-
-        mock_client = MagicMock()
-        mock_client.images.generate.return_value = mock_response
-
-        with patch("initrunner.agent.tools.image_gen._generate_openai") as mock_gen:
+        with patch("initrunner.agent.tools.image_gen._generate_openai_async") as mock_gen:
             mock_gen.return_value = b"hello"
 
             config = ImageGenToolConfig(output_dir=str(tmp_path))
             toolset = build_image_gen_toolset(config, _make_ctx())
             fn = toolset.tools["generate_image"].function
-            result = fn(prompt="a cat")
+            result = asyncio.run(fn(prompt="a cat"))
 
             assert tmp_path.name in result or "image_" in result
             mock_gen.assert_called_once()
 
     def test_stability_generate(self, tmp_path: Path):
-        with patch("initrunner.agent.tools.image_gen._generate_stability") as mock_gen:
+        with patch("initrunner.agent.tools.image_gen._generate_stability_async") as mock_gen:
             mock_gen.return_value = b"image_data"
 
             config = ImageGenToolConfig(
@@ -129,19 +122,19 @@ class TestGenerateImage:
             )
             toolset = build_image_gen_toolset(config, _make_ctx())
             fn = toolset.tools["generate_image"].function
-            result = fn(prompt="a dog")
+            result = asyncio.run(fn(prompt="a dog"))
 
             assert "image_" in result
             mock_gen.assert_called_once()
 
     def test_generate_error(self, tmp_path: Path):
-        with patch("initrunner.agent.tools.image_gen._generate_openai") as mock_gen:
+        with patch("initrunner.agent.tools.image_gen._generate_openai_async") as mock_gen:
             mock_gen.side_effect = RuntimeError("API error")
 
             config = ImageGenToolConfig(output_dir=str(tmp_path))
             toolset = build_image_gen_toolset(config, _make_ctx())
             fn = toolset.tools["generate_image"].function
-            result = fn(prompt="a cat")
+            result = asyncio.run(fn(prompt="a cat"))
             assert "Error:" in result
             assert "API error" in result
 
@@ -170,7 +163,7 @@ class TestEditImage:
                 config = ImageGenToolConfig(output_dir=str(tmp_path))
                 toolset = build_image_gen_toolset(config, _make_ctx())
                 fn = toolset.tools["edit_image"].function
-                result = fn(image_path=str(img_file), prompt="make it blue")
+                result = asyncio.run(fn(image_path=str(img_file), prompt="make it blue"))
 
                 assert "image_" in result
 
@@ -178,7 +171,7 @@ class TestEditImage:
         config = ImageGenToolConfig(output_dir=str(tmp_path))
         toolset = build_image_gen_toolset(config, _make_ctx())
         fn = toolset.tools["edit_image"].function
-        result = fn(image_path="/etc/passwd", prompt="edit")
+        result = asyncio.run(fn(image_path="/etc/passwd", prompt="edit"))
         assert "Error:" in result
 
     def test_path_with_input_root(self, tmp_path: Path):
@@ -204,7 +197,7 @@ class TestEditImage:
                 )
                 toolset = build_image_gen_toolset(config, _make_ctx())
                 fn = toolset.tools["edit_image"].function
-                result = fn(image_path=str(img_file), prompt="make it blue")
+                result = asyncio.run(fn(image_path=str(img_file), prompt="make it blue"))
 
                 assert "image_" in result
 
@@ -212,7 +205,7 @@ class TestEditImage:
         config = ImageGenToolConfig(output_dir=str(tmp_path))
         toolset = build_image_gen_toolset(config, _make_ctx())
         fn = toolset.tools["edit_image"].function
-        result = fn(image_path=str(tmp_path / "nope.png"), prompt="edit")
+        result = asyncio.run(fn(image_path=str(tmp_path / "nope.png"), prompt="edit"))
         assert "Error:" in result
 
 
@@ -224,7 +217,7 @@ class TestEditImage:
 class TestAsyncPath:
     def test_async_builder_registers_async_tools(self, tmp_path: Path):
         config = ImageGenToolConfig(output_dir=str(tmp_path))
-        toolset = build_image_gen_toolset(config, _make_ctx(prefer_async=True))
+        toolset = build_image_gen_toolset(config, _make_ctx())
         assert "generate_image" in toolset.tools
         assert "edit_image" in toolset.tools
         # The tool function should be a coroutine function
@@ -237,7 +230,7 @@ class TestAsyncPath:
             mock_gen.return_value = b"hello"
 
             config = ImageGenToolConfig(output_dir=str(tmp_path))
-            toolset = build_image_gen_toolset(config, _make_ctx(prefer_async=True))
+            toolset = build_image_gen_toolset(config, _make_ctx())
             fn = toolset.tools["generate_image"].function
             result = asyncio.run(fn(prompt="a cat"))
             assert "image_" in result

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -392,12 +392,11 @@ class TestStreamingStructured:
         from initrunner.agent.executor import execute_run_stream
 
         agent = MagicMock()
+        agent.run_stream = MagicMock(side_effect=TimeoutError("expected"))
         with patch("initrunner.agent.executor._prepare_run") as mock_prep:
             mock_prep.return_value = ("run-id", MagicMock(), {}, None)
-            with patch("initrunner.agent.executor._run_with_timeout") as mock_timeout:
-                mock_timeout.side_effect = TimeoutError("expected")
-                result, _ = execute_run_stream(agent, role, "test", skip_input_validation=True)
-                assert result.success is False  # failed on the mock, not on the guard
+            result, _ = execute_run_stream(agent, role, "test", skip_input_validation=True)
+            assert result.success is False  # failed on the mock, not on the guard
 
     def test_streaming_with_text_output_does_not_raise(self):
         """execute_run_stream does not raise for text output (normal path)."""
@@ -408,12 +407,11 @@ class TestStreamingStructured:
         from initrunner.agent.executor import execute_run_stream
 
         agent = MagicMock()
+        agent.run_stream = MagicMock(side_effect=TimeoutError("expected"))
         with patch("initrunner.agent.executor._prepare_run") as mock_prep:
             mock_prep.return_value = ("run-id", MagicMock(), {}, None)
-            with patch("initrunner.agent.executor._run_with_timeout") as mock_timeout:
-                mock_timeout.side_effect = TimeoutError("expected")
-                result, _ = execute_run_stream(agent, role, "test", skip_input_validation=True)
-                assert result.success is False
+            result, _ = execute_run_stream(agent, role, "test", skip_input_validation=True)
+            assert result.success is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import base64
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydantic_ai.messages import AudioUrl, BinaryContent, DocumentUrl, ImageUrl, VideoUrl
@@ -380,7 +380,7 @@ class TestExecutorMultimodal:
         usage.tool_calls = 0
         result_mock.usage.return_value = usage
         result_mock.all_messages.return_value = []
-        agent.run_sync.return_value = result_mock
+        agent.run = AsyncMock(return_value=result_mock)
 
         # Pass a multimodal prompt
         prompt = ["describe this", ImageUrl(url="https://example.com/img.png")]
@@ -388,9 +388,9 @@ class TestExecutorMultimodal:
 
         assert result.success is True
         assert result.output == "I see an image"
-        # Verify agent.run_sync was called with the multimodal prompt
-        agent.run_sync.assert_called_once()
-        call_args = agent.run_sync.call_args
+        # Verify agent.run was called with the multimodal prompt
+        agent.run.assert_called_once()
+        call_args = agent.run.call_args
         assert call_args[0][0] is prompt
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,6 +1,6 @@
 """Tests for runner/runner.py: DaemonTokenTracker, run_single, run_autonomous."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from initrunner.agent.executor import RunResult
 from initrunner.agent.schema.autonomy import AutonomyConfig
@@ -47,7 +47,7 @@ def _make_mock_agent(output: str = "Done", tokens: int = 100, tool_calls: int = 
     result.usage.return_value = usage
     result.all_messages.return_value = [{"role": "user", "content": "hi"}]
 
-    agent.run_sync.return_value = result
+    agent.run = AsyncMock(return_value=result)
     return agent
 
 
@@ -123,7 +123,7 @@ class TestRunSingle:
 
     def test_failed_run_displays_error(self):
         agent = MagicMock()
-        agent.run_sync.side_effect = ConnectionError("boom")
+        agent.run = AsyncMock(side_effect=ConnectionError("boom"))
         role = _make_role()
         result, _messages = run_single(agent, role, "Hi")
         assert result.success is False

--- a/tests/test_search_tools.py
+++ b/tests/test_search_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 from unittest.mock import MagicMock, patch
 
@@ -190,7 +191,7 @@ class TestDuckDuckGoToolIntegration:
             toolset = build_search_toolset(config, _make_ctx())
             fn = toolset.tools["web_search"].function
 
-            result = fn(query="test query")
+            result = asyncio.run(fn(query="test query"))
             assert "Test Result" in result
             assert "https://example.com" in result
             mock_provider.assert_called_once()
@@ -215,7 +216,7 @@ class TestDuckDuckGoToolIntegration:
             toolset = build_search_toolset(config, _make_ctx())
             fn = toolset.tools["news_search"].function
 
-            result = fn(query="test news")
+            result = asyncio.run(fn(query="test news"))
             assert "News Item" in result
             assert "https://news.example.com" in result
             assert mock_provider.call_args.kwargs["news"] is True
@@ -395,7 +396,7 @@ class TestSearchErrorHandling:
         ):
             toolset = build_search_toolset(config, _make_ctx())
             fn = toolset.tools["web_search"].function
-            result = fn(query="test")
+            result = asyncio.run(fn(query="test"))
             assert "ddgs is required" in result
 
     def test_search_api_error(self):
@@ -408,7 +409,7 @@ class TestSearchErrorHandling:
         ):
             toolset = build_search_toolset(config, _make_ctx())
             fn = toolset.tools["web_search"].function
-            result = fn(query="test")
+            result = asyncio.run(fn(query="test"))
             assert "Error: search failed:" in result
             assert "API rate limited" in result
 
@@ -422,7 +423,7 @@ class TestSearchErrorHandling:
         ):
             toolset = build_search_toolset(config, _make_ctx())
             fn = toolset.tools["web_search"].function
-            result = fn(query="test")
+            result = asyncio.run(fn(query="test"))
             assert "Error: search timed out after 5s" in result
 
     def test_news_search_api_error(self):
@@ -435,7 +436,7 @@ class TestSearchErrorHandling:
         ):
             toolset = build_search_toolset(config, _make_ctx())
             fn = toolset.tools["news_search"].function
-            result = fn(query="test")
+            result = asyncio.run(fn(query="test"))
             assert "Error: search failed:" in result
 
     def test_result_truncation(self):
@@ -457,7 +458,7 @@ class TestSearchErrorHandling:
         ):
             toolset = build_search_toolset(config, _make_ctx())
             fn = toolset.tools["web_search"].function
-            result = fn(query="test", num_results=20)
+            result = asyncio.run(fn(query="test", num_results=20))
             assert len(result) <= 65_536 + len("\n[truncated]")
 
     def test_num_results_capped_by_max_results(self):
@@ -471,7 +472,7 @@ class TestSearchErrorHandling:
         ):
             toolset = build_search_toolset(config, _make_ctx())
             fn = toolset.tools["web_search"].function
-            fn(query="test", num_results=100)
+            asyncio.run(fn(query="test", num_results=100))
             # Should be capped to max_results=3
             call_kwargs = mock_provider.call_args
             assert call_kwargs.kwargs["max_results"] == 3

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1033,18 +1033,6 @@ class TestStreamingHeaders:
         assert resp.headers.get("X-Accel-Buffering") == "no"
 
 
-class TestExecutorStreamUsage:
-    """Test that run_stream_sync is used correctly (fix #1)."""
-
-    def test_run_stream_sync_used_directly(self):
-        import inspect
-
-        from initrunner.agent.executor import execute_run_stream
-
-        source = inspect.getsource(execute_run_stream)
-        assert "agent.run_stream_sync(" in source
-
-
 class TestTokenQueueSize:
     """Test that token queue is large enough (fix #5)."""
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,11 +1,12 @@
 """Tests for the tools module."""
 
+import asyncio
 import os
 import sys
 import textwrap
 import types
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -77,7 +78,7 @@ class TestHttpToolset:
         config = HttpToolConfig(base_url="http://127.0.0.1")
         toolset = build_http_toolset(config, _make_ctx())
         fn = toolset.tools["http_request"].function
-        result = fn(method="GET", path="/")
+        result = asyncio.run(fn(method="GET", path="/"))
         assert "SSRF blocked" in result
 
     def test_builds_toolset(self):
@@ -546,7 +547,7 @@ class TestWebReaderToolset:
         config = WebReaderToolConfig()
         toolset = build_web_reader_toolset(config, _make_ctx())
         fn = toolset.tools["fetch_page"].function
-        result = fn(url="http://169.254.169.254/latest/meta-data/")
+        result = asyncio.run(fn(url="http://169.254.169.254/latest/meta-data/"))
         assert "SSRF blocked" in result
 
     def test_builds_toolset(self):
@@ -558,14 +559,14 @@ class TestWebReaderToolset:
         config = WebReaderToolConfig(allowed_domains=["example.com"])
         toolset = build_web_reader_toolset(config, _make_ctx())
         fn = toolset.tools["fetch_page"].function
-        result = fn(url="https://blocked.com/page")
+        result = asyncio.run(fn(url="https://blocked.com/page"))
         assert "not in the allowed domains" in result
 
     def test_domain_blocklist_rejects(self):
         config = WebReaderToolConfig(blocked_domains=["evil.com"])
         toolset = build_web_reader_toolset(config, _make_ctx())
         fn = toolset.tools["fetch_page"].function
-        result = fn(url="https://evil.com/page")
+        result = asyncio.run(fn(url="https://evil.com/page"))
         assert "blocked" in result
 
     def test_fetch_html_returns_markdown(self):
@@ -573,19 +574,11 @@ class TestWebReaderToolset:
         toolset = build_web_reader_toolset(config, _make_ctx())
         fn = toolset.tools["fetch_page"].function
 
-        html = "<html><body><h1>Title</h1><p>Hello world</p></body></html>"
-        mock_resp = MagicMock()
-        mock_resp.text = html
-        mock_resp.headers = {"content-type": "text/html; charset=utf-8"}
-        mock_resp.raise_for_status = MagicMock()
-
-        mock_client = MagicMock()
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_client.get.return_value = mock_resp
-
-        with patch("initrunner._html.httpx.Client", return_value=mock_client):
-            result = fn(url="https://example.com/page")
+        with patch(
+            "initrunner._html.fetch_url_as_markdown_async",
+            AsyncMock(return_value="# Title\n\nHello world"),
+        ):
+            result = asyncio.run(fn(url="https://example.com/page"))
 
         assert "Title" in result
         assert "Hello world" in result
@@ -595,19 +588,11 @@ class TestWebReaderToolset:
         toolset = build_web_reader_toolset(config, _make_ctx())
         fn = toolset.tools["fetch_page"].function
 
-        html = "<html><body><p>" + "x" * 1000 + "</p></body></html>"
-        mock_resp = MagicMock()
-        mock_resp.text = html
-        mock_resp.headers = {"content-type": "text/html"}
-        mock_resp.raise_for_status = MagicMock()
-
-        mock_client = MagicMock()
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_client.get.return_value = mock_resp
-
-        with patch("initrunner._html.httpx.Client", return_value=mock_client):
-            result = fn(url="https://example.com/page")
+        with patch(
+            "initrunner._html.fetch_url_as_markdown_async",
+            AsyncMock(return_value="prefix [truncated]"),
+        ):
+            result = asyncio.run(fn(url="https://example.com/page"))
 
         assert "[truncated]" in result
 
@@ -616,18 +601,11 @@ class TestWebReaderToolset:
         toolset = build_web_reader_toolset(config, _make_ctx())
         fn = toolset.tools["fetch_page"].function
 
-        mock_resp = MagicMock()
-        mock_resp.text = "plain text content"
-        mock_resp.headers = {"content-type": "text/plain"}
-        mock_resp.raise_for_status = MagicMock()
-
-        mock_client = MagicMock()
-        mock_client.__enter__ = MagicMock(return_value=mock_client)
-        mock_client.__exit__ = MagicMock(return_value=False)
-        mock_client.get.return_value = mock_resp
-
-        with patch("initrunner._html.httpx.Client", return_value=mock_client):
-            result = fn(url="https://example.com/data.txt")
+        with patch(
+            "initrunner._html.fetch_url_as_markdown_async",
+            AsyncMock(return_value="plain text content"),
+        ):
+            result = asyncio.run(fn(url="https://example.com/data.txt"))
 
         assert result == "plain text content"
 

--- a/tests/test_web_scraper.py
+++ b/tests/test_web_scraper.py
@@ -1,6 +1,7 @@
 """Tests for the web_scraper tool."""
 
-from unittest.mock import patch
+import asyncio
+from unittest.mock import AsyncMock, patch
 
 from initrunner.agent.schema.role import RoleDefinition
 from initrunner.agent.schema.tools import WebScraperToolConfig
@@ -51,7 +52,7 @@ class TestWebScraperToolset:
         ts = build_web_scraper_toolset(config, _make_ctx())
         func = _get_tool_func(ts, "scrape_page")
 
-        result = func(url="https://notallowed.com/page")
+        result = asyncio.run(func(url="https://notallowed.com/page"))
         assert "not in the allowed domains" in result
 
     def test_blocked_domain_rejects(self):
@@ -59,7 +60,7 @@ class TestWebScraperToolset:
         ts = build_web_scraper_toolset(config, _make_ctx())
         func = _get_tool_func(ts, "scrape_page")
 
-        result = func(url="https://blocked.com/page")
+        result = asyncio.run(func(url="https://blocked.com/page"))
         assert "blocked" in result
 
     def test_allowed_domain_accepts(self):
@@ -69,15 +70,15 @@ class TestWebScraperToolset:
 
         with (
             patch(
-                "initrunner.agent.tools.web_scraper.fetch_url_as_markdown",
-                return_value="Good content",
+                "initrunner._html.fetch_url_as_markdown_async",
+                AsyncMock(return_value="Good content"),
             ),
             patch(
-                "initrunner.agent.tools.web_scraper._embed_single",
-                return_value=[1.0, 0.0, 0.0, 0.0],
+                "initrunner.ingestion.embeddings.embed_single_async",
+                AsyncMock(return_value=[1.0, 0.0, 0.0, 0.0]),
             ),
         ):
-            result = func(url="https://good.com/page")
+            result = asyncio.run(func(url="https://good.com/page"))
 
         assert "Stored" in result
         assert "chunk" in result
@@ -90,17 +91,17 @@ class TestWebScraperToolset:
 
         with (
             patch(
-                "initrunner.agent.tools.web_scraper.fetch_url_as_markdown",
-                return_value="Test content for web scraper tool that is long enough",
+                "initrunner._html.fetch_url_as_markdown_async",
+                AsyncMock(return_value="Test content for web scraper tool that is long enough"),
             ),
             patch(
-                "initrunner.agent.tools.web_scraper._embed_single",
-                return_value=[1.0, 0.0, 0.0, 0.0],
+                "initrunner.ingestion.embeddings.embed_single_async",
+                AsyncMock(return_value=[1.0, 0.0, 0.0, 0.0]),
             ),
         ):
             ts = build_web_scraper_toolset(config, ctx)
             func = _get_tool_func(ts, "scrape_page")
-            result = func(url="https://example.com/page")
+            result = asyncio.run(func(url="https://example.com/page"))
 
         assert "Stored" in result
         assert "chunk" in result
@@ -112,10 +113,10 @@ class TestWebScraperToolset:
         func = _get_tool_func(ts, "scrape_page")
 
         with patch(
-            "initrunner.agent.tools.web_scraper.fetch_url_as_markdown",
-            side_effect=ConnectionError("timeout"),
+            "initrunner._html.fetch_url_as_markdown_async",
+            AsyncMock(side_effect=ConnectionError("timeout")),
         ):
-            result = func(url="https://down.example.com/page")
+            result = asyncio.run(func(url="https://down.example.com/page"))
 
         assert "Error fetching URL" in result
 
@@ -125,10 +126,10 @@ class TestWebScraperToolset:
         func = _get_tool_func(ts, "scrape_page")
 
         with patch(
-            "initrunner.agent.tools.web_scraper.fetch_url_as_markdown",
-            return_value="   ",
+            "initrunner._html.fetch_url_as_markdown_async",
+            AsyncMock(return_value="   "),
         ):
-            result = func(url="https://example.com/empty")
+            result = asyncio.run(func(url="https://example.com/empty"))
 
         assert "No content" in result
 


### PR DESCRIPTION
## Summary

The async migration left two sync/async parallel paths in place:

- `executor.py` had `_execute_orchestrated` (sync) and `_execute_orchestrated_async` duplicating ~95% of orchestration logic.
- Five tool modules carried parallel `_do_X` / `_do_X_async` impls selected at build time by `ToolBuildContext.prefer_async`.

The two duplications were causally linked: sync tool impls existed only to avoid running tools inside `asyncio.run` for CLI single-shot.

This PR makes async the core. Sync entry points (`execute_run`, `execute_run_resume`, `execute_run_stream`) become `run_sync` wrappers around their async counterparts. The resume body, previously fully duplicated, is factored into `_execute_resume_async_inner`. Tool modules (`http`, `web_reader`, `web_scraper`, `search`, `image_gen`) register async-only; sync `_do_X` helpers and `prefer_async` plumbing through `ToolBuildContext`, `build_toolsets`, and `build_agent` are removed.

Tests updated to mock the async path (`AsyncMock`, async context managers, `asyncio.run` wrapping). Two source-inspection tests dropped: they fingerprinted internals that no longer exist.

## Diff shape

- `executor.py`: 731 -> 423 lines
- Net: -828 / +361 across 21 files

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run ty check` clean
- [x] `uv run pytest tests/test_executor.py tests/test_executor_streaming.py tests/test_tools.py tests/test_search_tools.py tests/test_web_scraper.py tests/test_image_gen_tools.py -v` passes
- [x] CLI single-shot still wraps async correctly: `initrunner run examples/roles/...` returns rc=0
- [x] No remaining `prefer_async` references in source