### PR TITLE
fix: confine dashboard builder save + starter-seed reads to allowed dirs

### DIFF
--- a/docs/interfaces/dashboard.md
+++ b/docs/interfaces/dashboard.md
@@ -546,6 +546,10 @@ Without `--api-key`, the dashboard runs with no authentication (suitable for loc
 
 **Limitations**: Authentication mode supports the built-in same-origin UI and Bearer-token API clients. The cross-origin Vite dev server (`localhost:5173`) is not supported in authenticated mode. For development with auth, use the production build served by the backend.
 
+### Save path confinement
+
+The builder save endpoints (`/api/builder/save`, `/api/flow-builder/save`, `/api/team-builder/save`, and skill creation via `POST /api/skills`) write files to a request-supplied directory and filename. These are confined to the configured save directories: the discovered role directories plus any passed via `--roles-dir`, and for skills the directories surfaced by `GET /api/skills/directories`. A request whose target directory resolves outside those roots, or whose filename/project name contains a path separator or `..`, is rejected with `400`. This holds regardless of authentication, so an exposed-but-unauthenticated instance cannot be coerced into writing arbitrary files.
+
 ## API Reference
 
 All endpoints return JSON. Errors return `{"detail": "message"}`.

--- a/initrunner/dashboard/routers/_paths.py
+++ b/initrunner/dashboard/routers/_paths.py
@@ -1,0 +1,86 @@
+"""Path-validation helpers for dashboard save endpoints.
+
+Builder endpoints accept a target *directory* and *filename* from the request
+body. These helpers confine writes to the configured role/skill directories,
+rejecting absolute escapes and ``..`` traversal.
+
+The containment check mirrors the pattern already used in ``ingest.py``: resolve
+the full destination path *after* joining the request-supplied segment, then
+verify it is relative to an allowed root. Containment is the only test -- an
+absolute *directory* is permitted as long as it resolves within a root, because
+the UI offers absolute save dirs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class PathValidationError(ValueError):
+    """Raised when a requested write target escapes the allowed roots."""
+
+
+def safe_basename(name: str) -> str:
+    """Return the bare filename, rejecting separators and traversal.
+
+    Raises :class:`PathValidationError` if *name* is empty or differs from
+    ``Path(name).name`` (i.e. it contained a path separator or ``..``).
+    """
+    base = Path(name).name
+    if not base or base != name or base in (".", ".."):
+        raise PathValidationError(f"Invalid name: {name!r}")
+    return base
+
+
+def _within(path: Path, allowed_roots: list[Path]) -> bool:
+    resolved = path.resolve()
+    return any(resolved.is_relative_to(root.resolve()) for root in allowed_roots)
+
+
+def _validated_join(directory: str, segment: str, allowed_roots: list[Path]) -> Path:
+    base = safe_basename(segment)
+    target_dir = Path(directory).resolve()
+    if not _within(target_dir, allowed_roots):
+        raise PathValidationError(
+            f"Directory {directory!r} is not within an allowed root: "
+            f"{[str(r) for r in allowed_roots]}"
+        )
+    dest = (target_dir / base).resolve()
+    if not _within(dest, allowed_roots):
+        raise PathValidationError(f"Resolved path escapes allowed roots: {dest}")
+    return dest
+
+
+def validated_file_target(directory: str, filename: str, allowed_roots: list[Path]) -> Path:
+    """Resolve *directory*/*filename* and confirm it stays within an allowed root.
+
+    Returns the validated destination *file* path. Raises
+    :class:`PathValidationError` on any escape.
+    """
+    return _validated_join(directory, filename, allowed_roots)
+
+
+def validated_child_dir(directory: str, child: str, allowed_roots: list[Path]) -> Path:
+    """Resolve *directory*/*child* as a project subdirectory within an allowed root.
+
+    Returns the validated destination *directory* path. Raises
+    :class:`PathValidationError` on any escape.
+    """
+    return _validated_join(directory, child, allowed_roots)
+
+
+def role_save_roots(settings) -> list[Path]:
+    """Allowed roots for role/team/flow saves.
+
+    The configured role dirs plus the global ``~/.initrunner/roles`` -- the
+    latter is offered by the builder UI as a save dir even before discovery has
+    seen it (it is created on first run), so it must be permitted here too.
+    Mirrors the allowlist construction in ``builder.py``'s ``save_agent``.
+    """
+    from initrunner.config import get_roles_dir
+
+    roots = list(settings.get_role_dirs())
+    global_roles = get_roles_dir()
+    if global_roles not in roots:
+        roots.append(global_roles)
+    return roots

--- a/initrunner/dashboard/routers/builder.py
+++ b/initrunner/dashboard/routers/builder.py
@@ -252,10 +252,13 @@ async def seed_agent(
         elif req.mode == "starter":
             if not req.starter_slug:
                 raise ValueError("starter_slug is required for mode=starter")
-            from initrunner.services.starters import STARTERS_DIR
+            from initrunner.services.starters import resolve_starter_path
 
-            starter_path = STARTERS_DIR / f"{req.starter_slug}.yaml"
-            if not starter_path.is_file():
+            # resolve_starter_path confines the request-supplied slug to the
+            # bundled starters dir (no ../ or symlink escape) -- mirrors the
+            # flow/team builders.
+            starter_path = resolve_starter_path(req.starter_slug)
+            if starter_path is None:
                 raise ValueError(f"Starter not found: {req.starter_slug}")
             raw = starter_path.read_text(encoding="utf-8")
             # Rewrite model block with the user's chosen provider/model

--- a/initrunner/dashboard/routers/builder.py
+++ b/initrunner/dashboard/routers/builder.py
@@ -413,23 +413,20 @@ async def save_agent(
     req: SaveRequest,
     role_cache: Annotated[RoleCache, Depends(get_role_cache)],
 ) -> SaveResponse:
-    from initrunner.config import get_roles_dir
+    from initrunner.dashboard.routers._paths import (
+        PathValidationError,
+        role_save_roots,
+        validated_file_target,
+    )
     from initrunner.services.agent_builder import BuilderSession
 
-    # Validate directory is within discovered role dirs or ~/.initrunner/roles
-    allowed_dirs = list(role_cache._settings.get_role_dirs())
-    global_roles = get_roles_dir()
-    if global_roles not in allowed_dirs:
-        allowed_dirs.append(global_roles)
-    target_dir = Path(req.directory).resolve()
-    if not any(target_dir.is_relative_to(d.resolve()) for d in allowed_dirs):
-        raise HTTPException(
-            status_code=400,
-            detail=f"Directory {req.directory} is not within a configured role directory. "
-            f"Allowed: {[str(d) for d in allowed_dirs]}",
-        )
+    # Confine the write to a configured role dir (filename basename-guarded).
+    allowed_dirs = role_save_roots(role_cache._settings)
+    try:
+        output_path = validated_file_target(req.directory, req.filename, allowed_dirs)
+    except PathValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    output_path = target_dir / req.filename
     session = BuilderSession()
     session.yaml_text = req.yaml_text
     if req.sidecar_source is not None:

--- a/initrunner/dashboard/routers/flow_builder.py
+++ b/initrunner/dashboard/routers/flow_builder.py
@@ -17,6 +17,12 @@ from initrunner.dashboard.deps import (
     get_role_cache,
 )
 from initrunner.dashboard.routers._agent_options import build_agent_options
+from initrunner.dashboard.routers._paths import (
+    PathValidationError,
+    role_save_roots,
+    safe_basename,
+    validated_child_dir,
+)
 from initrunner.dashboard.routers._provider_options import gather_provider_options
 from initrunner.dashboard.schemas import (
     FlowBuilderOptionsResponse,
@@ -185,7 +191,15 @@ async def save_flow(
     req: FlowSaveRequest,
     flow_cache: Annotated[FlowCache, Depends(get_flow_cache)],
 ) -> FlowSaveResponse:
-    project_dir = Path(req.directory) / req.project_name
+    allowed_roots = role_save_roots(flow_cache._settings)
+    try:
+        project_dir = validated_child_dir(req.directory, req.project_name, allowed_roots)
+        # Role keys are request-controlled; confine each to a bare filename now
+        # so a traversal key is a clean 400 rather than a mid-write failure.
+        for name in req.role_yamls:
+            safe_basename(name)
+    except PathValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     if project_dir.exists() and not req.force:
         raise HTTPException(
@@ -234,7 +248,10 @@ def _write_and_validate(project_dir: Path, flow_yaml: str, role_yamls: dict[str,
     flow_path = project_dir / "flow.yaml"
     flow_path.write_text(flow_yaml)
 
-    for filename, role_yaml in role_yamls.items():
+    # Role keys are request-controlled; confine each to a bare filename in roles/.
+    safe_role_yamls = {safe_basename(name): role_yaml for name, role_yaml in role_yamls.items()}
+
+    for filename, role_yaml in safe_role_yamls.items():
         (roles_dir / filename).write_text(role_yaml)
 
     issues: list[str] = []
@@ -246,7 +263,7 @@ def _write_and_validate(project_dir: Path, flow_yaml: str, role_yamls: dict[str,
         issues.append(f"flow.yaml: {exc}")
         valid = False
 
-    for filename in role_yamls:
+    for filename in safe_role_yamls:
         role_path = roles_dir / filename
         try:
             load_role(role_path)

--- a/initrunner/dashboard/routers/skills.py
+++ b/initrunner/dashboard/routers/skills.py
@@ -234,11 +234,24 @@ async def create_skill(
     cache: Annotated[SkillCache, Depends(get_skill_cache)],
 ) -> SkillCreateResponse:
     from initrunner.agent.skills import SkillLoadError
+    from initrunner.dashboard.routers._paths import PathValidationError, safe_basename
     from initrunner.services.skill_service import create_skill as svc_create
+    from initrunner.services.skill_service import get_skill_directories
 
-    directory = Path(body.directory)
+    # Confine creation to a valid skill directory; basename-guard the skill name.
+    allowed_dirs = await asyncio.to_thread(get_skill_directories, cache._settings.get_role_dirs())
     try:
-        path = await asyncio.to_thread(svc_create, body.name, directory, body.provider)
+        name = safe_basename(body.name)
+        target_dir = Path(body.directory).resolve()
+        if not any(target_dir == Path(d).resolve() for d in allowed_dirs):
+            raise PathValidationError(
+                f"Directory {body.directory!r} is not a configured skill directory"
+            )
+    except PathValidationError as exc:
+        raise HTTPException(400, detail=str(exc)) from exc
+
+    try:
+        path = await asyncio.to_thread(svc_create, name, target_dir, body.provider)
     except SkillLoadError as exc:
         raise HTTPException(409, detail=str(exc)) from exc
 

--- a/initrunner/dashboard/routers/team_builder.py
+++ b/initrunner/dashboard/routers/team_builder.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from pathlib import Path
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException  # type: ignore[import-not-found]
@@ -34,11 +33,9 @@ router = APIRouter(prefix="/api/team-builder", tags=["team-builder"])
 async def get_options(
     role_cache: Annotated[RoleCache, Depends(get_role_cache)],
 ) -> TeamBuilderOptionsResponse:
-    from initrunner.dashboard.config import DashboardSettings
     from initrunner.dashboard.routers._agent_options import build_agent_options
 
-    settings = DashboardSettings()
-    opts = await gather_provider_options(settings)
+    opts = await gather_provider_options(role_cache._settings)
 
     return TeamBuilderOptionsResponse(
         providers=opts.providers,
@@ -189,25 +186,22 @@ async def save_team(
     body: TeamSaveRequest,
     cache: Annotated[TeamCache, Depends(get_team_cache)],
 ) -> TeamSaveResponse:
-    from initrunner.dashboard.config import DashboardSettings
+    from initrunner.dashboard.routers._paths import (
+        PathValidationError,
+        role_save_roots,
+        validated_file_target,
+    )
     from initrunner.services.team_builder import (
         build_team_next_steps,
         validate_team_yaml,
     )
 
-    settings = DashboardSettings()
-    allowed_dirs = settings.get_role_dirs()
-
-    target_dir = Path(body.directory).resolve()
-    in_allowed = any(
-        target_dir == d.resolve() or str(target_dir).startswith(str(d.resolve()))
-        for d in allowed_dirs
-    )
-    if not in_allowed:
-        raise HTTPException(
-            400,
-            detail=f"Directory {body.directory} is not within configured role directories",
-        )
+    allowed_dirs = role_save_roots(cache._settings)
+    try:
+        output_path = validated_file_target(body.directory, body.filename, allowed_dirs)
+    except PathValidationError as exc:
+        raise HTTPException(400, detail=str(exc)) from exc
+    target_dir = output_path.parent
 
     team, issues = await asyncio.to_thread(validate_team_yaml, body.yaml_text)
     errors = [i.message for i in issues if i.severity == "error"]
@@ -221,7 +215,6 @@ async def save_team(
             team_id="",
         )
 
-    output_path = target_dir / body.filename
     if output_path.exists() and not body.force:
         raise HTTPException(409, detail=f"File already exists: {output_path}")
 

--- a/initrunner/examples.py
+++ b/initrunner/examples.py
@@ -142,8 +142,13 @@ def copy_example(name: str, output_dir: Path) -> list[Path]:
     category_dirs = {"role": "roles", "flow": "flows", "skill": "skills"}
     category_subdir = category_dirs.get(entry.category, entry.category)
 
+    # Confine every write to output_dir. Catalog paths are trusted today, but a
+    # `..` or absolute rel_path must never escape the target directory.
+    out_root = output_dir.resolve()
     for rel_path in entry.files:
         dest = output_dir / rel_path
+        if not dest.resolve().is_relative_to(out_root):
+            raise ExampleDownloadError(f"Unsafe example file path: {rel_path}")
         if dest.exists():
             raise FileExistsError(f"File already exists: {dest}")
 

--- a/initrunner/services/skill_service.py
+++ b/initrunner/services/skill_service.py
@@ -291,6 +291,10 @@ def create_skill(name: str, directory: Path, provider: str = "openai") -> Path:
     """Scaffold a new skill in directory format. Returns path to SKILL.md."""
     from initrunner.templates import template_skill
 
+    # Guard against path traversal via the skill name.
+    if not name or Path(name).name != name or name in (".", ".."):
+        raise SkillLoadError(f"Invalid skill name: {name!r}")
+
     skill_dir = directory / name
     skill_file = skill_dir / "SKILL.md"
 

--- a/initrunner/services/starters.py
+++ b/initrunner/services/starters.py
@@ -253,20 +253,40 @@ def get_starter(slug: str) -> StarterEntry | None:
     return None
 
 
+def _within_starters(candidate: Path) -> Path | None:
+    """Resolve *candidate* and return it only if it stays inside STARTERS_DIR.
+
+    ``resolve()`` collapses ``..`` and follows symlinks; ``is_relative_to`` then
+    rejects anything that lands outside the bundled starters directory. This
+    confines a request-supplied starter name so it cannot read arbitrary files.
+    """
+    root = STARTERS_DIR.resolve()
+    try:
+        resolved = candidate.resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+    return resolved if resolved.is_relative_to(root) else None
+
+
 def resolve_starter_path(name: str) -> Path | None:
-    """Resolve a starter name to its YAML path, or None if not found."""
+    """Resolve a starter name to its YAML path, or None if not found.
+
+    *name* is request-supplied (builder ``starter_slug``); every candidate is
+    confined to STARTERS_DIR, so a crafted name (``../``, absolute, or a symlink)
+    cannot escape to read arbitrary files.
+    """
     # Single-file starters
     for ext in (".yaml", ".yml"):
-        candidate = STARTERS_DIR / f"{name}{ext}"
-        if candidate.is_file():
+        candidate = _within_starters(STARTERS_DIR / f"{name}{ext}")
+        if candidate is not None and candidate.is_file():
             return candidate
 
     # Composite starters
-    composite = STARTERS_DIR / name
-    if composite.is_dir():
+    composite = _within_starters(STARTERS_DIR / name)
+    if composite is not None and composite.is_dir():
         for candidate_name in ("flow.yaml", "role.yaml"):
-            candidate = composite / candidate_name
-            if candidate.is_file():
+            candidate = _within_starters(composite / candidate_name)
+            if candidate is not None and candidate.is_file():
                 return candidate
 
     return None

--- a/tests/test_dashboard/test_flow_builder_router.py
+++ b/tests/test_dashboard/test_flow_builder_router.py
@@ -44,7 +44,9 @@ class _IsolatedRoleCache(RoleCache):
 
 class _IsolatedFlowCache(FlowCache):
     def __init__(self, dirs: list[Path]):
-        settings = DashboardSettings()
+        # Expose the scanned dirs as allowed save roots so the router's
+        # path-containment check (which reads flow_cache._settings) permits them.
+        settings = DashboardSettings(extra_role_dirs=list(dirs))
         self._settings = settings
         self._dirs = dirs
         self._cache: dict = {}
@@ -376,7 +378,7 @@ def test_validate_missing_spec(client):
 # -- POST /api/flow-builder/save -------------------------------------------
 
 
-def test_save_flow(client, tmp_path):
+def test_save_flow(client, role_dir):
     tc, _ = client
     seed_resp = tc.post(
         "/api/flow-builder/seed",
@@ -396,7 +398,7 @@ def test_save_flow(client, tmp_path):
         json={
             "flow_yaml": seed_data["flow_yaml"],
             "role_yamls": seed_data["role_yamls"],
-            "directory": str(tmp_path),
+            "directory": str(role_dir),
             "project_name": "saved",
         },
     )
@@ -405,10 +407,10 @@ def test_save_flow(client, tmp_path):
     assert data["valid"] is True
     assert "flow_id" in data
     assert len(data["next_steps"]) > 0
-    assert (tmp_path / "saved" / "flow.yaml").exists()
+    assert (role_dir / "saved" / "flow.yaml").exists()
 
 
-def test_save_conflict(client, tmp_path):
+def test_save_conflict(client, role_dir):
     tc, _ = client
     seed_resp = tc.post(
         "/api/flow-builder/seed",
@@ -428,7 +430,7 @@ def test_save_conflict(client, tmp_path):
         json={
             "flow_yaml": seed_data["flow_yaml"],
             "role_yamls": seed_data["role_yamls"],
-            "directory": str(tmp_path),
+            "directory": str(role_dir),
             "project_name": "dup",
         },
     )
@@ -438,7 +440,7 @@ def test_save_conflict(client, tmp_path):
         json={
             "flow_yaml": seed_data["flow_yaml"],
             "role_yamls": seed_data["role_yamls"],
-            "directory": str(tmp_path),
+            "directory": str(role_dir),
             "project_name": "dup",
         },
     )

--- a/tests/test_dashboard/test_path_traversal.py
+++ b/tests/test_dashboard/test_path_traversal.py
@@ -1,0 +1,291 @@
+"""Path-traversal hardening for dashboard builder save endpoints.
+
+Covers the ``_paths`` helper directly and the four save endpoints that write
+request-controlled paths (agent/flow/team/skill builders), asserting that
+escapes are rejected (HTTP 400) and nothing is written outside an allowed root.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi", reason="dashboard extras not installed")
+
+from starlette.testclient import TestClient
+
+from initrunner.dashboard.app import create_app
+from initrunner.dashboard.config import DashboardSettings
+from initrunner.dashboard.deps import (
+    FlowCache,
+    RoleCache,
+    SkillCache,
+    TeamCache,
+    get_flow_cache,
+    get_role_cache,
+    get_skill_cache,
+    get_team_cache,
+)
+from initrunner.dashboard.routers._paths import (
+    PathValidationError,
+    role_save_roots,
+    safe_basename,
+    validated_child_dir,
+    validated_file_target,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests: _paths helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["../x", "a/b", "", "..", "/abs", "a/../b"])
+def test_safe_basename_rejects(bad):
+    with pytest.raises(PathValidationError):
+        safe_basename(bad)
+
+
+def test_safe_basename_accepts_plain_name():
+    assert safe_basename("role.yaml") == "role.yaml"
+
+
+def test_validated_file_target_accepts_absolute_in_root(tmp_path):
+    root = tmp_path / "roles"
+    root.mkdir()
+    # Absolute directory must be allowed as long as it resolves within a root.
+    dest = validated_file_target(str(root), "agent.yaml", [root])
+    assert dest == (root / "agent.yaml").resolve()
+
+
+def test_validated_file_target_rejects_prefix_sibling(tmp_path):
+    root = tmp_path / "roles"
+    root.mkdir()
+    sibling = tmp_path / "roles_evil"
+    sibling.mkdir()
+    # String-prefix bypass: /roles_evil must NOT pass a /roles allowlist.
+    with pytest.raises(PathValidationError):
+        validated_file_target(str(sibling), "agent.yaml", [root])
+
+
+def test_validated_file_target_rejects_traversal_filename(tmp_path):
+    root = tmp_path / "roles"
+    root.mkdir()
+    with pytest.raises(PathValidationError):
+        validated_file_target(str(root), "../outside.yaml", [root])
+
+
+def test_validated_child_dir_rejects_absolute_child(tmp_path):
+    root = tmp_path / "roles"
+    root.mkdir()
+    with pytest.raises(PathValidationError):
+        validated_child_dir(str(root), "/etc", [root])
+
+
+# ---------------------------------------------------------------------------
+# Endpoint fixtures
+# ---------------------------------------------------------------------------
+
+
+def _settings_allowing(dirs: list[Path]) -> DashboardSettings:
+    return DashboardSettings(extra_role_dirs=list(dirs))
+
+
+class _Cache:
+    """Mixin giving a cache configurable allowed roots and a no-op refresh."""
+
+    def _init(self, settings: DashboardSettings) -> None:
+        self._settings = settings
+        self._cache: dict = {}
+
+    def refresh(self):
+        return self._cache
+
+    def refresh_one(self, *args, **kwargs):
+        return None
+
+
+class _RoleCache(_Cache, RoleCache):
+    def __init__(self, settings):
+        self._init(settings)
+
+
+class _FlowCache(_Cache, FlowCache):
+    def __init__(self, settings):
+        self._init(settings)
+
+
+class _TeamCache(_Cache, TeamCache):
+    def __init__(self, settings):
+        self._init(settings)
+
+
+class _SkillCache(_Cache, SkillCache):
+    def __init__(self, settings):
+        self._init(settings)
+
+
+@pytest.fixture
+def allowed_root(tmp_path):
+    d = tmp_path / "roles"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def client(allowed_root):
+    settings = _settings_allowing([allowed_root])
+    app = create_app(settings)
+    app.dependency_overrides[get_role_cache] = lambda: _RoleCache(settings)
+    app.dependency_overrides[get_flow_cache] = lambda: _FlowCache(settings)
+    app.dependency_overrides[get_team_cache] = lambda: _TeamCache(settings)
+    app.dependency_overrides[get_skill_cache] = lambda: _SkillCache(settings)
+    return TestClient(app)
+
+
+_AGENT_YAML = (
+    "apiVersion: initrunner/v1\nkind: Agent\nmetadata:\n  name: a\n"
+    "spec:\n  role: |\n    You help.\n  model:\n    provider: openai\n    name: gpt-4o\n"
+)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint regression tests -- one per vuln
+# ---------------------------------------------------------------------------
+
+
+def test_agent_save_rejects_traversal_filename(client, tmp_path, allowed_root):
+    resp = client.post(
+        "/api/builder/save",
+        json={
+            "yaml_text": _AGENT_YAML,
+            "directory": str(allowed_root),
+            "filename": "../outside.yaml",
+        },
+    )
+    assert resp.status_code == 400
+    assert not (tmp_path / "outside.yaml").exists()
+
+
+def test_agent_save_rejects_outside_directory(client, tmp_path, allowed_root):
+    resp = client.post(
+        "/api/builder/save",
+        json={
+            "yaml_text": _AGENT_YAML,
+            "directory": str(tmp_path / "elsewhere"),
+            "filename": "a.yaml",
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_flow_save_rejects_outside_directory(client, tmp_path, allowed_root):
+    resp = client.post(
+        "/api/flow-builder/save",
+        json={
+            "flow_yaml": "apiVersion: initrunner/v1\nkind: Flow\n",
+            "role_yamls": {},
+            "directory": str(tmp_path),
+            "project_name": "proj",
+        },
+    )
+    assert resp.status_code == 400
+    assert not (tmp_path / "proj").exists()
+
+
+def test_flow_save_rejects_absolute_project_name(client, allowed_root):
+    resp = client.post(
+        "/api/flow-builder/save",
+        json={
+            "flow_yaml": "apiVersion: initrunner/v1\nkind: Flow\n",
+            "role_yamls": {},
+            "directory": str(allowed_root),
+            "project_name": "/etc/evil",
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_flow_save_rejects_traversal_role_key(client, tmp_path, allowed_root):
+    # project_name is valid, but a role_yamls key tries to escape roles/.
+    resp = client.post(
+        "/api/flow-builder/save",
+        json={
+            "flow_yaml": "apiVersion: initrunner/v1\nkind: Flow\n",
+            "role_yamls": {"../../evil.yaml": "apiVersion: initrunner/v1\nkind: Agent\n"},
+            "directory": str(allowed_root),
+            "project_name": "proj",
+        },
+    )
+    assert resp.status_code == 400
+    assert not (tmp_path / "evil.yaml").exists()
+
+
+def test_team_save_rejects_prefix_sibling(client, tmp_path):
+    sibling = tmp_path / "roles_evil"
+    sibling.mkdir()
+    from initrunner.services.team_builder import build_blank_team_yaml
+
+    yaml_text = build_blank_team_yaml("t", provider="openai")
+    resp = client.post(
+        "/api/team-builder/save",
+        json={
+            "yaml_text": yaml_text,
+            "directory": str(sibling),
+            "filename": "t.yaml",
+            "force": False,
+        },
+    )
+    assert resp.status_code == 400
+    assert not (sibling / "t.yaml").exists()
+
+
+def test_team_save_rejects_traversal_filename(client, tmp_path, allowed_root):
+    from initrunner.services.team_builder import build_blank_team_yaml
+
+    yaml_text = build_blank_team_yaml("t", provider="openai")
+    resp = client.post(
+        "/api/team-builder/save",
+        json={
+            "yaml_text": yaml_text,
+            "directory": str(allowed_root),
+            "filename": "../evil.yaml",
+            "force": False,
+        },
+    )
+    assert resp.status_code == 400
+    assert not (tmp_path / "evil.yaml").exists()
+
+
+def test_skill_create_rejects_outside_directory(client, tmp_path):
+    resp = client.post(
+        "/api/skills",
+        json={"name": "my-skill", "directory": str(tmp_path / "nope"), "provider": "openai"},
+    )
+    assert resp.status_code == 400
+
+
+def test_skill_create_rejects_traversal_name(client, allowed_root):
+    skill_dir = allowed_root / "skills"
+    skill_dir.mkdir()
+    resp = client.post(
+        "/api/skills",
+        json={"name": "../evil", "directory": str(skill_dir), "provider": "openai"},
+    )
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Positive: first-run save to the global roles dir even if discovery missed it
+# ---------------------------------------------------------------------------
+
+
+def test_role_save_roots_includes_global_roles_dir(tmp_path, monkeypatch):
+    import initrunner.config as cfg
+
+    global_roles = tmp_path / "dot-initrunner" / "roles"
+    monkeypatch.setattr(cfg, "get_roles_dir", lambda: global_roles)
+
+    settings = DashboardSettings()  # no extra dirs, discovery may not include global
+    roots = role_save_roots(settings)
+    assert global_roles in roots

--- a/tests/test_dashboard/test_team_builder_router.py
+++ b/tests/test_dashboard/test_team_builder_router.py
@@ -14,7 +14,9 @@ class _IsolatedTeamCache(TeamCache):
     """TeamCache that only scans specific dirs."""
 
     def __init__(self, dirs: list[Path]):
-        settings = DashboardSettings()
+        # Expose the scanned dirs as allowed save roots so the router's
+        # path-containment check (which reads cache._settings) permits them.
+        settings = DashboardSettings(extra_role_dirs=list(dirs))
         self._settings = settings
         self._discover_fn = None
         self._path_attr = "path"

--- a/tests/test_starters_service.py
+++ b/tests/test_starters_service.py
@@ -90,6 +90,40 @@ class TestResolveStarterPath:
     def test_returns_none_for_unknown(self):
         assert resolve_starter_path("does-not-exist") is None
 
+    def test_rejects_parent_traversal(self):
+        # The slug is request-supplied (builder starter_slug); ../ must not escape.
+        assert resolve_starter_path("../../../../etc/passwd") is None
+        assert resolve_starter_path("../" * 6 + "etc/hosts") is None
+
+    def test_rejects_absolute_name(self):
+        assert resolve_starter_path("/etc/passwd") is None
+
+    def test_rejects_symlink_escape(self, tmp_path, monkeypatch):
+        # A symlink inside the starters dir pointing outside must not be followed
+        # into an arbitrary read.
+        import initrunner.services.starters as starters_mod
+
+        fake_starters = tmp_path / "_starters"
+        fake_starters.mkdir()
+        secret = tmp_path / "secret.yaml"
+        secret.write_text("kind: Secret\n", encoding="utf-8")
+        (fake_starters / "evil.yaml").symlink_to(secret)
+        monkeypatch.setattr(starters_mod, "STARTERS_DIR", fake_starters)
+
+        assert resolve_starter_path("evil") is None
+
+    def test_confined_path_still_resolves(self, tmp_path, monkeypatch):
+        import initrunner.services.starters as starters_mod
+
+        fake_starters = tmp_path / "_starters"
+        fake_starters.mkdir()
+        (fake_starters / "ok.yaml").write_text("kind: Agent\n", encoding="utf-8")
+        monkeypatch.setattr(starters_mod, "STARTERS_DIR", fake_starters)
+
+        path = resolve_starter_path("ok")
+        assert path is not None and path.is_file()
+        assert path.resolve().is_relative_to(fake_starters.resolve())
+
 
 class TestDeriveFeatures:
     def test_rag_feature(self):


### PR DESCRIPTION
## Summary

Path-traversal hardening for the dashboard builder. Two commits:

1. **`5c3e2ff`** (already on branch) — confine builder *save* paths to configured role/skill dirs via the new `dashboard/routers/_paths.py` helpers (`safe_basename`, `validated_file_target`).
2. **`136cccf`** — confine the *starter-seed read* paths, which the save fix did not cover.

### Starter-seed traversal (new)

The agent builder's `mode=starter` seed built `STARTERS_DIR / f"{slug}.yaml"` directly from the request body, and `resolve_starter_path` (used by the flow/team builders) joined the request name with only an `is_file()` guard. A slug like `../../../etc/passwd` escaped the bundled starters dir and read arbitrary `.yaml` files (unauthenticated when the dashboard runs without an API key — see the separate fail-open-auth PR).

**Fix:**
- `resolve_starter_path` now confines every candidate to `STARTERS_DIR` via `resolve()` + `is_relative_to` (rejects `../`, absolute paths, and symlink escapes).
- `builder.py` seed mode routes through `resolve_starter_path` instead of building the path itself — same pattern the flow/team builders already use.
- `examples.copy_example` asserts each write stays within `output_dir` (defense in depth; catalog paths are trusted today).

## Testing

- `uv run pytest tests/test_starters_service.py tests/test_dashboard/test_path_traversal.py -q` — passes; adds traversal/symlink/absolute regression tests for `resolve_starter_path`.
- `ruff check`, `ruff format`, `ty check` clean on changed files.

Found during a security audit of the codebase; part of a series of hardening PRs.