### PR TITLE
fix: fail closed on network-exposed dashboard/MCP/A2A + block DNS rebinding

### DIFF
--- a/docs/interfaces/a2a.md
+++ b/docs/interfaces/a2a.md
@@ -14,8 +14,9 @@ initrunner a2a serve role.yaml
 # With authentication
 initrunner a2a serve role.yaml --api-key my-secret-key
 
-# Custom host/port
-initrunner a2a serve role.yaml --host 0.0.0.0 --port 9000
+# Custom host/port. Binding a non-loopback host without --api-key fails closed:
+# a key is generated and printed rather than serving the agent unauthenticated.
+initrunner a2a serve role.yaml --host 0.0.0.0 --port 9000 --api-key my-secret-key
 ```
 
 The server exposes:
@@ -29,7 +30,7 @@ The server exposes:
 | `role_file` | `Path` | *(required)* | Path to the role YAML file. |
 | `--host` | `str` | `127.0.0.1` | Host to bind to. Use `0.0.0.0` to expose on all interfaces. |
 | `--port` | `int` | `8000` | Port to listen on. |
-| `--api-key` | `str` | `None` | API key for Bearer token authentication. When set, all endpoints except the agent card require `Authorization: Bearer <key>`. |
+| `--api-key` | `str` | `None` | API key for Bearer token authentication. When set, all endpoints except the agent card require `Authorization: Bearer <key>`. Binding a non-loopback `--host` without a key fails closed — one is generated and printed so the JSON-RPC endpoint is never served unauthenticated off-host. |
 | `--cors-origin` | `str` | `None` | Allowed CORS origin. Can be repeated. |
 | `--audit-db` | `Path` | `~/.initrunner/audit.db` | Path to audit database. |
 | `--no-audit` | `bool` | `false` | Disable audit logging. |

--- a/docs/interfaces/dashboard.md
+++ b/docs/interfaces/dashboard.md
@@ -522,9 +522,11 @@ See [Design System](design-system.md) for the full reference (colors, typography
 
 By default, the dashboard binds to `127.0.0.1` (localhost only). It is not accessible from other machines.
 
-The `--expose` flag binds to `0.0.0.0`, making it accessible on all network interfaces. When exposing the dashboard, use `--api-key` to require authentication.
+The `--expose` flag binds to `0.0.0.0`, making it accessible on all network interfaces. **Exposing fails closed:** if you pass `--expose` without `--api-key`, the dashboard generates a random key, prints it once, and requires it — it never serves unauthenticated on a non-loopback interface. Pass `--api-key` (or set `INITRUNNER_DASHBOARD_API_KEY`) to choose your own.
 
-The dashboard can execute any discovered agent with any prompt. It has the same access as `initrunner run` on the command line.
+The dashboard can execute any discovered agent with any prompt, write provider keys, and edit role/flow YAML. It has the same access as `initrunner run` on the command line — treat access to it as access to the host.
+
+**DNS-rebinding protection:** the localhost dashboard rejects requests whose `Host` header isn't `localhost`/`127.0.0.1` (a `TrustedHost` allowlist), so a malicious web page can't drive it through a rebinding hostname. When `--expose`d, the allowlist is permissive (authentication is the protection); pin it with `allowed_hosts` if you terminate at a fixed hostname.
 
 ### Authentication
 
@@ -542,7 +544,9 @@ When enabled:
 - **Public endpoints**: Only `/api/health` and `/login` are accessible without authentication. All other routes (including `/api/docs` and `/api/openapi.json`) require a valid key.
 - **Logout**: `POST /logout` clears the session cookie.
 
-Without `--api-key`, the dashboard runs with no authentication (suitable for localhost-only use).
+Without `--api-key`, a **localhost** dashboard runs with no authentication (suitable for local-only use). Binding to a non-loopback host (`--expose`) always requires a key — one is generated and printed if you don't supply it.
+
+The session cookie's `Secure` flag is set from the connection scheme (`request.url.scheme`), which uvicorn only marks HTTPS for a trusted proxy (`--forwarded-allow-ips`); the client-supplied `X-Forwarded-Proto` header is not trusted on its own.
 
 **Limitations**: Authentication mode supports the built-in same-origin UI and Bearer-token API clients. The cross-origin Vite dev server (`localhost:5173`) is not supported in authenticated mode. For development with auth, use the production build served by the backend.
 

--- a/docs/interfaces/mcp-gateway.md
+++ b/docs/interfaces/mcp-gateway.md
@@ -135,6 +135,7 @@ Synopsis: `initrunner mcp toolkit [OPTIONS]`
 | `--transport, -t` | `str` | `stdio` | Transport: `stdio`, `sse`, or `streamable-http`. |
 | `--host` | `str` | `127.0.0.1` | Host to bind to (sse/http only). |
 | `--port` | `int` | `8080` | Port to listen on (sse/http only). |
+| `--api-key` | `str` | `None` | Require this Bearer token (sse/http). Env: `INITRUNNER_MCP_API_KEY`. Fails closed on a non-loopback host (see [Network security](#network-security)). |
 | `--server-name` | `str` | `initrunner-toolkit` | MCP server name (overrides config). |
 
 ### Config File Format
@@ -222,11 +223,18 @@ Synopsis: `initrunner mcp serve ROLE_FILES... [OPTIONS]`
 | `--transport, -t` | `str` | `stdio` | Transport protocol: `stdio`, `sse`, or `streamable-http`. |
 | `--host` | `str` | `127.0.0.1` | Host to bind to (sse/streamable-http only). |
 | `--port` | `int` | `8080` | Port to listen on (sse/streamable-http only). |
+| `--api-key` | `str` | `None` | Require this Bearer token (sse/streamable-http). Env: `INITRUNNER_MCP_API_KEY`. See [Network security](#network-security). |
 | `--server-name` | `str` | `initrunner` | MCP server name reported to clients. |
 | `--pass-through` | `bool` | `false` | Also expose the agents' own MCP tools directly (see [Pass-Through Mode](#pass-through-mode)). |
 | `--audit-db` | `Path` | `~/.initrunner/audit.db` | Path to audit database. |
 | `--no-audit` | `bool` | `false` | Disable audit logging. |
 | `--skill-dir` | `Path` | `None` | Extra skill search directory. |
+
+`initrunner mcp toolkit` and `initrunner mcp browser` take the same `--api-key` option.
+
+## Network security
+
+The gateway invokes agents and tools, so the HTTP transports (`sse`, `streamable-http`) **fail closed**: binding a non-loopback host (e.g. `--host 0.0.0.0`) without `--api-key` generates a random Bearer token and prints it once rather than serving unauthenticated. Supply `--api-key` (or `INITRUNNER_MCP_API_KEY`) to set your own; clients then send `Authorization: Bearer <key>`. `stdio` is local-only and needs no key. A loopback bind may run keyless.
 
 ## Transports
 

--- a/initrunner/cli/a2a_cmd.py
+++ b/initrunner/cli/a2a_cmd.py
@@ -42,6 +42,12 @@ def a2a_serve(
 
     require_a2a()
 
+    from initrunner.middleware import resolve_exposed_api_key
+
+    # Fail closed: the A2A JSON-RPC endpoint drives the agent. Don't serve it
+    # off-host without auth.
+    api_key, generated_key = resolve_exposed_api_key(host, api_key)
+
     resolved_model = resolve_model_override(model)
     with command_context(
         role_file,
@@ -53,7 +59,12 @@ def a2a_serve(
         console.print(f"[bold]A2A Server:[/bold] {role.metadata.name}")
         console.print(f"  Endpoint:   http://{host}:{port}")
         console.print(f"  Agent card: http://{host}:{port}/.well-known/agent-card.json")
-        if api_key:
+        if generated_key is not None:
+            console.print(
+                "  Auth:       [yellow]enabled[/yellow] -- generated key (no --api-key given):\n"
+                f"              [bold]{generated_key}[/bold]"
+            )
+        elif api_key:
             console.print("  Auth:       [yellow]enabled[/yellow] (Bearer token required)")
         if cors_origin:
             console.print(f"  CORS:       {', '.join(cors_origin)}")

--- a/initrunner/cli/dashboard_cmd.py
+++ b/initrunner/cli/dashboard_cmd.py
@@ -21,6 +21,13 @@ def launch_dashboard(
     """Start the dashboard server (blocking)."""
     from initrunner.dashboard.app import create_app  # type: ignore[import-not-found]
     from initrunner.dashboard.config import DashboardSettings  # type: ignore[import-not-found]
+    from initrunner.middleware import resolve_exposed_api_key
+
+    # Fail closed: a dashboard on 0.0.0.0 exposes agent execution, secret writes,
+    # and role/flow editing. If exposed without a key, generate one rather than
+    # serve unauthenticated.
+    bind_host = "0.0.0.0" if expose else "127.0.0.1"
+    api_key, generated_key = resolve_exposed_api_key(bind_host, api_key)
 
     settings = DashboardSettings(
         port=port,
@@ -30,15 +37,15 @@ def launch_dashboard(
     )
 
     if expose:
-        if api_key:
+        if generated_key is not None:
             console.print(
-                "[yellow]Warning: dashboard exposed on all interfaces "
-                "-- authentication enabled[/yellow]"
+                "[yellow]Dashboard exposed on all interfaces with no --api-key.[/yellow]\n"
+                "[yellow]Generated one so it is not open -- sign in with:[/yellow]\n"
+                f"  [bold]{generated_key}[/bold]"
             )
         else:
             console.print(
-                "[yellow]Warning: dashboard exposed on all interfaces "
-                "-- no authentication enabled[/yellow]"
+                "[yellow]Dashboard exposed on all interfaces -- authentication enabled.[/yellow]"
             )
 
     app = create_app(settings)

--- a/initrunner/cli/mcp_cmd.py
+++ b/initrunner/cli/mcp_cmd.py
@@ -68,6 +68,14 @@ def mcp_serve(
     ] = "stdio",
     host: Annotated[str, typer.Option(help="Host to bind to (sse/http)")] = "127.0.0.1",
     port: Annotated[int, typer.Option(help="Port to listen on (sse/http)")] = 8080,
+    api_key: Annotated[
+        str | None,
+        typer.Option(
+            "--api-key",
+            envvar="INITRUNNER_MCP_API_KEY",
+            help="Require this Bearer token (sse/http). Auto-generated if exposed without one.",
+        ),
+    ] = None,
     server_name: Annotated[str, typer.Option(help="MCP server name")] = "initrunner",
     pass_through: Annotated[
         bool, typer.Option("--pass-through", help="Also expose agent MCP tools directly")
@@ -120,7 +128,7 @@ def mcp_serve(
         if transport != "stdio":
             err_console.print(f"  Endpoint: {host}:{port}")
 
-        run_mcp_gateway(mcp, transport=transport, host=host, port=port)
+        run_mcp_gateway(mcp, transport=transport, host=host, port=port, api_key=api_key)
     except Exception as e:
         err_console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1) from None
@@ -148,6 +156,14 @@ def mcp_toolkit(
     ] = "stdio",
     host: Annotated[str, typer.Option(help="Host to bind to (sse/http)")] = "127.0.0.1",
     port: Annotated[int, typer.Option(help="Port to listen on (sse/http)")] = 8080,
+    api_key: Annotated[
+        str | None,
+        typer.Option(
+            "--api-key",
+            envvar="INITRUNNER_MCP_API_KEY",
+            help="Require this Bearer token (sse/http). Auto-generated if exposed without one.",
+        ),
+    ] = None,
     server_name: Annotated[
         str | None, typer.Option(help="MCP server name (overrides config)")
     ] = None,
@@ -210,7 +226,7 @@ def mcp_toolkit(
         err_console.print(f"  Endpoint: {host}:{port}")
 
     try:
-        run_mcp_gateway(mcp, transport=transport, host=host, port=port)
+        run_mcp_gateway(mcp, transport=transport, host=host, port=port, api_key=api_key)
     except Exception as e:
         err_console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1) from None
@@ -223,6 +239,14 @@ def mcp_browser(
     ] = "stdio",
     host: Annotated[str, typer.Option(help="Host to bind to (sse/http)")] = "127.0.0.1",
     port: Annotated[int, typer.Option(help="Port to listen on (sse/http)")] = 8080,
+    api_key: Annotated[
+        str | None,
+        typer.Option(
+            "--api-key",
+            envvar="INITRUNNER_MCP_API_KEY",
+            help="Require this Bearer token (sse/http). Auto-generated if exposed without one.",
+        ),
+    ] = None,
     session_name: Annotated[
         str | None, typer.Option("--session-name", help="Browser session name for persistence")
     ] = None,
@@ -276,7 +300,7 @@ def mcp_browser(
         err_console.print(f"  Endpoint: {host}:{port}")
 
     try:
-        run_mcp_gateway(mcp, transport=transport, host=host, port=port)
+        run_mcp_gateway(mcp, transport=transport, host=host, port=port, api_key=api_key)
     except Exception as e:
         err_console.print(f"[red]Error:[/red] {e}")
         raise typer.Exit(1) from None

--- a/initrunner/dashboard/app.py
+++ b/initrunner/dashboard/app.py
@@ -72,6 +72,25 @@ def create_app(settings: DashboardSettings | None = None) -> FastAPI:
         allow_headers=["*"],
     )
 
+    # Host-header allowlist (anti-DNS-rebinding). A malicious web page can point
+    # its hostname at 127.0.0.1 and drive a keyless localhost dashboard through
+    # the victim's browser; rejecting unexpected Host headers blocks that. When
+    # exposed we default to permissive (mandatory auth is the protection) unless
+    # the operator pins allowed_hosts.
+    if settings.allowed_hosts is not None:
+        allowed_hosts = settings.allowed_hosts
+    elif settings.expose:
+        allowed_hosts = ["*"]
+    else:
+        allowed_hosts = ["localhost", "127.0.0.1", "::1", "testserver"]
+    if "*" not in allowed_hosts:
+        from starlette.middleware.trustedhost import TrustedHostMiddleware
+
+        app.add_middleware(
+            TrustedHostMiddleware,  # type: ignore[arg-type]
+            allowed_hosts=allowed_hosts,
+        )
+
     # -- Dependency overrides: inject caches as singletons ------------------
     app.dependency_overrides[get_role_cache] = lambda: role_cache
     app.dependency_overrides[get_flow_cache] = lambda: flow_cache
@@ -103,10 +122,14 @@ def create_app(settings: DashboardSettings | None = None) -> FastAPI:
             return value if value.startswith("/") else "/"
 
         def _is_https(request: Request) -> bool:
-            """True when the request arrived over HTTPS (direct or proxied)."""
-            if request.url.scheme == "https":
-                return True
-            return request.headers.get("x-forwarded-proto", "") == "https"
+            """True when the request arrived over HTTPS.
+
+            Relies on ``request.url.scheme``, which uvicorn only sets from
+            ``X-Forwarded-Proto`` when the proxy is explicitly trusted
+            (``--forwarded-allow-ips``). We must not read the header directly --
+            any client can spoof it to strip the cookie's ``Secure`` flag.
+            """
+            return request.url.scheme == "https"
 
         @app.get("/login", include_in_schema=False)
         async def login_page(

--- a/initrunner/dashboard/config.py
+++ b/initrunner/dashboard/config.py
@@ -19,6 +19,10 @@ class DashboardSettings:
     expose: bool = False
     api_key: str | None = None
     extra_role_dirs: list[Path] = field(default_factory=list)
+    # Host header allowlist (anti-DNS-rebinding). None -> default policy in
+    # create_app: loopback names only when not exposed, permissive when exposed
+    # (mandatory auth is the protection there).
+    allowed_hosts: list[str] | None = None
 
     @property
     def host(self) -> str:

--- a/initrunner/mcp/gateway.py
+++ b/initrunner/mcp/gateway.py
@@ -187,14 +187,42 @@ def run_mcp_gateway(
     transport: str = "stdio",
     host: str = "127.0.0.1",
     port: int = 8080,
+    api_key: str | None = None,
 ) -> None:
-    """Run an MCP gateway server with the specified transport."""
+    """Run an MCP gateway server with the specified transport.
+
+    For the network transports (sse / streamable-http) this fails closed: a
+    non-loopback bind without an API key gets a generated one (printed once) so
+    the gateway -- which can invoke agents and tools -- is never reachable
+    off-host unauthenticated. *api_key*, when present, is enforced as a static
+    Bearer token.
+    """
     if transport not in _VALID_TRANSPORTS:
         raise ValueError(f"Unknown transport: {transport!r}. Expected: stdio, sse, streamable-http")
 
     if transport == "stdio":
+        # stdio is not network-exposed; auth is N/A.
         mcp.run(transport="stdio", show_banner=False)
-    elif transport == "sse":
+        return
+
+    from initrunner.middleware import resolve_exposed_api_key
+
+    effective_key, generated_key = resolve_exposed_api_key(host, api_key)
+    if effective_key:
+        from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+
+        mcp.auth = StaticTokenVerifier({effective_key: {"client_id": "initrunner", "scopes": []}})
+    if generated_key is not None:
+        from rich.console import Console
+
+        Console(stderr=True).print(
+            "[yellow]MCP gateway exposed without --api-key; generated one so it is "
+            "not open. Send it as a Bearer token:[/yellow]\n"
+            f"  [bold]{generated_key}[/bold]"
+        )
+
+    # Pass literal transports so the FastMCP Literal type is satisfied.
+    if transport == "sse":
         mcp.run(transport="sse", host=host, port=port)
     else:
         mcp.run(transport="streamable-http", host=host, port=port)

--- a/initrunner/middleware.py
+++ b/initrunner/middleware.py
@@ -7,10 +7,63 @@ suitable for ``BaseHTTPMiddleware``.
 from __future__ import annotations
 
 import hmac
+import ipaddress
+import logging
+import secrets
 from collections.abc import Callable, Set
 
 from starlette.requests import Request
 from starlette.responses import Response
+
+_logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Fail-closed network exposure — refuse to serve an unauthenticated server on a
+# non-loopback interface
+# ---------------------------------------------------------------------------
+
+_LOOPBACK_HOSTNAMES = frozenset({"127.0.0.1", "localhost", "::1", ""})
+
+
+def is_loopback_host(host: str | None) -> bool:
+    """Return True when *host* binds only the loopback interface.
+
+    Loopback binds are reachable only from the same machine, so running them
+    without authentication is an accepted local-dev convenience. Everything else
+    (``0.0.0.0``, ``::``, a LAN/public IP, or a hostname) is treated as exposed.
+    """
+    h = (host or "").strip().lower()
+    if h.startswith("[") and h.endswith("]"):
+        h = h[1:-1]
+    if h in _LOOPBACK_HOSTNAMES:
+        return True
+    try:
+        return ipaddress.ip_address(h).is_loopback
+    except ValueError:
+        return False
+
+
+def resolve_exposed_api_key(host: str | None, api_key: str | None) -> tuple[str | None, str | None]:
+    """Fail closed when a server is exposed off-host without authentication.
+
+    Returns ``(effective_key, generated_key)``:
+
+    - Loopback bind -> ``(api_key, None)``: local-only servers may run keyless.
+    - Non-loopback bind with a key -> ``(api_key, None)``: honoured as-is.
+    - Non-loopback bind with **no** key -> a random key is generated and returned
+      as both values, so the server is never reachable off-host unauthenticated.
+      Callers surface ``generated_key`` once (it is the only way in).
+    """
+    if api_key or is_loopback_host(host):
+        return api_key, None
+    generated = secrets.token_urlsafe(32)
+    _logger.warning(
+        "Server bound to non-loopback host %r without an API key; generated one to "
+        "avoid serving unauthenticated. Set --api-key (or the env var) to choose your own.",
+        host,
+    )
+    return generated, generated
+
 
 # ---------------------------------------------------------------------------
 # Path predicates — control which routes a middleware applies to

--- a/tests/test_dashboard/test_host_header.py
+++ b/tests/test_dashboard/test_host_header.py
@@ -1,0 +1,44 @@
+"""Host-header allowlist (anti-DNS-rebinding) on the dashboard app."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi", reason="dashboard extras not installed")
+
+from starlette.testclient import TestClient
+
+from initrunner.dashboard.app import create_app
+from initrunner.dashboard.config import DashboardSettings
+
+
+def test_rejects_unexpected_host():
+    # Default (loopback) policy allows only localhost names. A rebinding page that
+    # sends Host: evil.com to the local dashboard must be rejected.
+    app = create_app(DashboardSettings())
+    client = TestClient(app)
+    resp = client.get("/api/health", headers={"host": "evil.com"})
+    assert resp.status_code == 400
+
+
+def test_allows_localhost_host():
+    app = create_app(DashboardSettings())
+    client = TestClient(app)
+    resp = client.get("/api/health", headers={"host": "localhost"})
+    assert resp.status_code == 200
+
+
+def test_exposed_is_permissive_by_default():
+    # When exposed, mandatory auth is the protection; Host is not pinned unless
+    # the operator sets allowed_hosts.
+    app = create_app(DashboardSettings(expose=True, api_key="k"))
+    client = TestClient(app)
+    resp = client.get("/api/health", headers={"host": "anything.example"})
+    assert resp.status_code == 200
+
+
+def test_explicit_allowed_hosts_pin():
+    app = create_app(DashboardSettings(expose=True, api_key="k", allowed_hosts=["good.example"]))
+    client = TestClient(app)
+    assert client.get("/api/health", headers={"host": "good.example"}).status_code == 200
+    assert client.get("/api/health", headers={"host": "bad.example"}).status_code == 400

--- a/tests/test_server_exposure.py
+++ b/tests/test_server_exposure.py
@@ -1,0 +1,88 @@
+"""Fail-closed network-exposure auth for dashboard / MCP / A2A servers.
+
+Covers the shared helpers in ``initrunner.middleware`` plus the MCP gateway's
+auto-applied Bearer auth, asserting a non-loopback bind is never served
+unauthenticated.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from initrunner.middleware import is_loopback_host, resolve_exposed_api_key
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["127.0.0.1", "localhost", "::1", "[::1]", "", "127.5.0.1"],
+)
+def test_is_loopback_true(host):
+    assert is_loopback_host(host) is True
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["0.0.0.0", "::", "192.168.1.10", "10.0.0.5", "example.com", "0.0.0.0:8100"],
+)
+def test_is_loopback_false(host):
+    # 0.0.0.0:8100 has a port and is not a bare IP -> treated as exposed (safe default)
+    assert is_loopback_host(host) is False
+
+
+def test_loopback_without_key_stays_keyless():
+    effective, generated = resolve_exposed_api_key("127.0.0.1", None)
+    assert effective is None
+    assert generated is None
+
+
+def test_loopback_honours_explicit_key():
+    effective, generated = resolve_exposed_api_key("127.0.0.1", "secret")
+    assert effective == "secret"
+    assert generated is None
+
+
+def test_exposed_with_key_is_unchanged():
+    effective, generated = resolve_exposed_api_key("0.0.0.0", "secret")
+    assert effective == "secret"
+    assert generated is None
+
+
+def test_exposed_without_key_generates_one():
+    effective, generated = resolve_exposed_api_key("0.0.0.0", None)
+    assert generated is not None
+    assert effective == generated
+    assert len(generated) >= 32  # token_urlsafe(32)
+
+
+def test_mcp_gateway_applies_auth_when_exposed(monkeypatch):
+    """run_mcp_gateway must set a token verifier before serving a network transport."""
+    pytest.importorskip("fastmcp")
+    from fastmcp import FastMCP
+
+    from initrunner.mcp.gateway import run_mcp_gateway
+
+    mcp = FastMCP("test")
+    captured = {}
+
+    def _fake_run(**kwargs):
+        captured["auth"] = mcp.auth
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(mcp, "run", _fake_run)
+
+    # Exposed host, no key -> a verifier must be installed before run.
+    run_mcp_gateway(mcp, transport="streamable-http", host="0.0.0.0", port=8080)
+    assert captured["auth"] is not None
+    assert type(captured["auth"]).__name__ == "StaticTokenVerifier"
+
+
+def test_mcp_gateway_stdio_needs_no_auth(monkeypatch):
+    pytest.importorskip("fastmcp")
+    from fastmcp import FastMCP
+
+    from initrunner.mcp.gateway import run_mcp_gateway
+
+    mcp = FastMCP("test")
+    monkeypatch.setattr(mcp, "run", lambda **kw: None)
+    run_mcp_gateway(mcp, transport="stdio")
+    assert mcp.auth is None


### PR DESCRIPTION
## Summary

Authentication on the HTTP-facing servers was **opt-in**. With no API key configured, the dashboard, the MCP gateway (sse / streamable-http), and the A2A server served *every* endpoint unauthenticated — and `--expose` only printed a warning before binding `0.0.0.0`. Unauthenticated reach included running agents, MCP tool calls (which spawn subprocesses), `POST /api/providers/save-key`, `POST /api/system/default-model`, and builder role/flow/team/skill writes + deletes.

## Changes

**Shared helper (`middleware.py`)**
- `is_loopback_host()` and `resolve_exposed_api_key(host, api_key)`. A non-loopback bind with no key gets a generated one (surfaced once) so the server is never reachable off-host unauthenticated; loopback stays keyless for local dev.

**Servers fail closed**
- `dashboard_cmd`, `a2a_cmd`, and the MCP gateway resolve through the helper before binding.
- MCP gateway applies the key as a FastMCP `StaticTokenVerifier`; adds `--api-key` (env `INITRUNNER_MCP_API_KEY`) to `serve` / `toolkit` / `browser`. Enforcement lives in `run_mcp_gateway`, so programmatic callers are covered too.

**Dashboard DNS-rebinding (`app.py`)**
- Add `TrustedHostMiddleware`: loopback-only Host allowlist when not exposed (blocks a malicious page from driving the local dashboard via a rebinding hostname). Permissive when exposed (mandatory auth is the protection) unless `allowed_hosts` is pinned.

**Cookie hardening (`app.py`)**
- Stop trusting client-supplied `X-Forwarded-Proto` for the cookie `Secure` flag; rely on `request.url.scheme` (uvicorn only sets it for explicitly trusted proxies).

## Testing

- `tests/test_server_exposure.py` — loopback detection, fail-closed key generation, and that `run_mcp_gateway` installs a token verifier before serving a network transport.
- `tests/test_dashboard/test_host_header.py` — TrustedHost rejects unexpected Host (400), allows localhost, and honors explicit `allowed_hosts`.
- Existing dashboard/a2a/mcp suites pass (585 passed). `ruff` + `ty` clean.

Found during a security audit; part of a series of hardening PRs.