### PR TITLE
fix: pin validated IP to defeat SSRF DNS rebinding + widen blocked ranges

### DIFF
--- a/initrunner/agent/_urls.py
+++ b/initrunner/agent/_urls.py
@@ -32,15 +32,24 @@ def _resolve_with_timeout(hostname: str, port: int, timeout: float) -> list[_Add
 # Blocked IP ranges (RFC 1918, link-local, loopback, etc.)
 # ---------------------------------------------------------------------------
 _BLOCKED_NETWORKS = [
-    ipaddress.ip_network("0.0.0.0/8"),
-    ipaddress.ip_network("127.0.0.0/8"),
-    ipaddress.ip_network("10.0.0.0/8"),
-    ipaddress.ip_network("172.16.0.0/12"),
-    ipaddress.ip_network("192.168.0.0/16"),
-    ipaddress.ip_network("169.254.0.0/16"),
-    ipaddress.ip_network("::1/128"),
-    ipaddress.ip_network("fc00::/7"),
-    ipaddress.ip_network("fe80::/10"),
+    ipaddress.ip_network("0.0.0.0/8"),  # "this" network (incl. 0.0.0.0)
+    ipaddress.ip_network("127.0.0.0/8"),  # loopback
+    ipaddress.ip_network("10.0.0.0/8"),  # RFC 1918
+    ipaddress.ip_network("172.16.0.0/12"),  # RFC 1918
+    ipaddress.ip_network("192.168.0.0/16"),  # RFC 1918
+    ipaddress.ip_network("169.254.0.0/16"),  # link-local (incl. 169.254.169.254 metadata)
+    ipaddress.ip_network("100.64.0.0/10"),  # RFC 6598 CGNAT (Alibaba metadata 100.100.100.200)
+    ipaddress.ip_network("192.0.0.0/24"),  # RFC 6890 IETF protocol assignments
+    ipaddress.ip_network("192.0.2.0/24"),  # TEST-NET-1
+    ipaddress.ip_network("198.18.0.0/15"),  # RFC 2544 benchmarking
+    ipaddress.ip_network("198.51.100.0/24"),  # TEST-NET-2
+    ipaddress.ip_network("203.0.113.0/24"),  # TEST-NET-3
+    ipaddress.ip_network("240.0.0.0/4"),  # reserved/future (incl. 255.255.255.255 broadcast)
+    ipaddress.ip_network("::1/128"),  # IPv6 loopback
+    ipaddress.ip_network("::/128"),  # IPv6 unspecified
+    ipaddress.ip_network("fc00::/7"),  # IPv6 unique-local
+    ipaddress.ip_network("fe80::/10"),  # IPv6 link-local
+    ipaddress.ip_network("2001:db8::/32"),  # IPv6 documentation
 ]
 
 
@@ -117,11 +126,90 @@ def validate_url_ssrf(url: str, *, dns_timeout: float = _DNS_TIMEOUT) -> str | N
     return None
 
 
+def _resolve_safe_ip(host: str, port: int, dns_timeout: float) -> str:
+    """Resolve *host* and return a single validated public IP to connect to.
+
+    Raises :class:`SSRFBlocked` if the host is missing, fails to resolve, or any
+    resolved address is private/internal. Returning a concrete IP lets the caller
+    pin the connection to it, so a rebinding resolver cannot swap in a private
+    address between validation and connect (the DNS-rebinding TOCTOU).
+    """
+    if not host:
+        raise SSRFBlocked("SSRF blocked: URL has no hostname")
+
+    # Bracketed IPv6 literal -> strip brackets for ip_address().
+    bare = host[1:-1] if host.startswith("[") and host.endswith("]") else host
+
+    try:
+        literal = ipaddress.ip_address(bare)
+    except ValueError:
+        literal = None
+
+    if literal is not None:
+        if _is_private_ip(literal):
+            raise SSRFBlocked(f"SSRF blocked: '{host}' is a private address {literal}")
+        return bare
+
+    try:
+        infos = _resolve_with_timeout(bare, port, timeout=dns_timeout)
+    except socket.gaierror as exc:
+        raise SSRFBlocked(f"SSRF blocked: DNS resolution failed for '{host}': {exc}") from exc
+    except TimeoutError as exc:
+        raise SSRFBlocked(
+            f"SSRF blocked: DNS resolution timed out for '{host}' after {dns_timeout}s"
+        ) from exc
+
+    pinned: str | None = None
+    for _family, _type, _proto, _canonname, sockaddr in infos:
+        ip_str = str(sockaddr[0])
+        addr = ipaddress.ip_address(ip_str)
+        # Block if ANY resolved address is private -- never connect when the host
+        # multiplexes public and internal addresses.
+        if _is_private_ip(addr):
+            raise SSRFBlocked(f"SSRF blocked: '{host}' resolves to private address {addr}")
+        if pinned is None:
+            pinned = ip_str
+
+    if pinned is None:
+        raise SSRFBlocked(f"SSRF blocked: '{host}' did not resolve to any address")
+    return pinned
+
+
+def _pin_request(request: httpx.Request, dns_timeout: float) -> None:
+    """Rewrite *request* in place to connect to a validated, pinned IP.
+
+    Validates the scheme, resolves+checks the host once, then points the URL at
+    the resolved IP while preserving the original ``Host`` header and setting the
+    TLS ``sni_hostname`` so certificate verification still targets the hostname.
+    httpx therefore connects to the exact IP we validated -- it does not
+    re-resolve -- which closes the DNS-rebinding window. Runs per redirect hop.
+    """
+    url = request.url
+    scheme = url.scheme.lower()
+    if scheme not in ("http", "https"):
+        raise SSRFBlocked(f"SSRF blocked: scheme '{url.scheme}' is not allowed")
+
+    host = url.host
+    port = url.port or (443 if scheme == "https" else 80)
+    pinned_ip = _resolve_safe_ip(host, port, dns_timeout)
+
+    if pinned_ip == host:
+        return  # already an IP literal; nothing to rewrite
+
+    # Preserve the Host header (httpx set it to the original host[:port]) and the
+    # TLS SNI/cert hostname, then repoint the connection at the pinned IP.
+    request.headers.setdefault("host", url.netloc.decode("ascii"))
+    request.extensions = {**request.extensions, "sni_hostname": host}
+    request.url = url.copy_with(host=pinned_ip)
+
+
 class SSRFSafeTransport(httpx.HTTPTransport):
     """httpx transport that rejects requests to private/internal IPs.
 
-    Because httpx invokes ``transport.handle_request()`` for every request
-    in the redirect chain, this also blocks redirect-based SSRF.
+    Validation pins the resolved IP for the actual connection, so a rebinding
+    resolver cannot swap in a private address after the check. httpx invokes
+    ``handle_request()`` for every redirect hop, so this also blocks
+    redirect-based SSRF.
     """
 
     def __init__(self, *, dns_timeout: float = _DNS_TIMEOUT, **kwargs: Any) -> None:
@@ -129,9 +217,7 @@ class SSRFSafeTransport(httpx.HTTPTransport):
         self._dns_timeout = dns_timeout
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
-        error = validate_url_ssrf(str(request.url), dns_timeout=self._dns_timeout)
-        if error:
-            raise SSRFBlocked(error)
+        _pin_request(request, self._dns_timeout)
         return super().handle_request(request)
 
 
@@ -143,7 +229,5 @@ class AsyncSSRFSafeTransport(httpx.AsyncHTTPTransport):
         self._dns_timeout = dns_timeout
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        error = validate_url_ssrf(str(request.url), dns_timeout=self._dns_timeout)
-        if error:
-            raise SSRFBlocked(error)
+        _pin_request(request, self._dns_timeout)
         return await super().handle_async_request(request)

--- a/initrunner/mcp/browser.py
+++ b/initrunner/mcp/browser.py
@@ -89,7 +89,16 @@ def _run_ab(args: list[str], config: BrowserMCPConfig) -> str:
 
 
 def _check_url(url: str, config: BrowserMCPConfig) -> str | None:
-    """Validate a URL for SSRF and domain filters. Returns error or None."""
+    """Validate a URL for SSRF and domain filters. Returns error or None.
+
+    NOTE: this is a best-effort pre-check, NOT a containment boundary. The
+    ``agent-browser`` subprocess does its own DNS resolution and fetching (and
+    can be steered to new URLs by page content/redirects), so a determined
+    attacker can bypass this check via DNS rebinding or in-page navigation. For
+    real isolation, run ``agent-browser`` inside a sandbox/network namespace with
+    egress filtered to deny RFC-1918/link-local/CGNAT/metadata ranges, and set a
+    strict ``allowed_domains`` allowlist.
+    """
     parsed = urlparse(url)
     if parsed.scheme == "file":
         return "Error: file:// URLs are not allowed"

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -6,9 +6,15 @@ import socket
 import time
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
-from initrunner.agent._urls import SSRFBlocked, SSRFSafeTransport, validate_url_ssrf
+from initrunner.agent._urls import (
+    SSRFBlocked,
+    SSRFSafeTransport,
+    _resolve_safe_ip,
+    validate_url_ssrf,
+)
 
 
 def _mock_getaddrinfo(*addrs: str):
@@ -189,21 +195,31 @@ class TestSSRFSafeTransport:
     def test_raises_for_private_ip(self, mock_dns):
         mock_dns.side_effect = _mock_getaddrinfo("127.0.0.1")
         transport = SSRFSafeTransport()
-        request = MagicMock()
-        request.url = "http://localhost/"
         with pytest.raises(SSRFBlocked, match="SSRF blocked"):
-            transport.handle_request(request)
+            transport.handle_request(httpx.Request("GET", "http://localhost/"))
 
     @patch("initrunner.agent._urls.socket.getaddrinfo")
-    def test_calls_super_for_safe_url(self, mock_dns):
+    def test_pins_validated_ip_for_safe_url(self, mock_dns):
+        # The connection must target the SAME IP we validated (no re-resolution),
+        # with Host + TLS SNI preserved -- this is what closes the rebinding TOCTOU.
         mock_dns.side_effect = _mock_getaddrinfo("93.184.216.34")
         transport = SSRFSafeTransport()
-        request = MagicMock()
-        request.url = "https://example.com/"
+        request = httpx.Request("GET", "https://example.com/path")
         with patch("httpx.HTTPTransport.handle_request", return_value=MagicMock()) as mock_super:
             result = transport.handle_request(request)
-            mock_super.assert_called_once_with(request)
+            mock_super.assert_called_once()
+            passed = mock_super.call_args.args[0]
+            assert passed.url.host == "93.184.216.34"  # pinned to the validated IP
+            assert passed.extensions.get("sni_hostname") == "example.com"
+            assert passed.headers["host"] == "example.com"  # original Host preserved
             assert result is mock_super.return_value
+
+    @patch("initrunner.agent._urls.socket.getaddrinfo")
+    def test_blocks_non_http_scheme(self, mock_dns):
+        transport = SSRFSafeTransport()
+        with pytest.raises(SSRFBlocked, match="scheme"):
+            transport.handle_request(httpx.Request("GET", "file://etc/passwd"))
+        mock_dns.assert_not_called()
 
     def test_dns_timeout_parameter(self):
         transport = SSRFSafeTransport(dns_timeout=5.0)
@@ -213,3 +229,57 @@ class TestSSRFSafeTransport:
         """SSRFBlocked is a subclass of httpx.HTTPError for catch compatibility."""
         exc = SSRFBlocked("test")
         assert isinstance(exc, Exception)
+
+
+# ---------------------------------------------------------------------------
+# Newly-blocked CIDR ranges (CGNAT, TEST-NET, benchmarking, reserved, IPv6 doc)
+# ---------------------------------------------------------------------------
+class TestExpandedBlocklist:
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "100.64.0.1",  # CGNAT
+            "100.100.100.200",  # Alibaba metadata (inside CGNAT)
+            "192.0.0.1",  # IETF protocol assignments
+            "192.0.2.5",  # TEST-NET-1
+            "198.18.0.1",  # benchmarking
+            "198.51.100.7",  # TEST-NET-2
+            "203.0.113.9",  # TEST-NET-3
+            "240.0.0.1",  # reserved
+            "255.255.255.255",  # broadcast (inside 240/4)
+        ],
+    )
+    @patch("initrunner.agent._urls.socket.getaddrinfo")
+    def test_ipv4_ranges_blocked(self, mock_dns, ip):
+        mock_dns.side_effect = _mock_getaddrinfo(ip)
+        assert validate_url_ssrf("http://host.example/") is not None
+
+    @patch("initrunner.agent._urls.socket.getaddrinfo")
+    def test_ipv6_doc_and_unspecified_blocked(self, mock_dns):
+        for ip in ("2001:db8::1", "::"):
+            mock_dns.side_effect = _mock_getaddrinfo_v6(ip)
+            assert validate_url_ssrf("http://host.example/") is not None
+
+
+# ---------------------------------------------------------------------------
+# IP pinning helper + DNS-rebinding defence
+# ---------------------------------------------------------------------------
+class TestResolveSafeIp:
+    def test_public_ip_literal_returned(self):
+        assert _resolve_safe_ip("93.184.216.34", 443, 10.0) == "93.184.216.34"
+
+    def test_private_ip_literal_raises(self):
+        with pytest.raises(SSRFBlocked):
+            _resolve_safe_ip("169.254.169.254", 80, 10.0)
+
+    @patch("initrunner.agent._urls.socket.getaddrinfo")
+    def test_mixed_resolution_blocks(self, mock_dns):
+        # public + private together -> never connect (the rebinding multiplexing case)
+        mock_dns.side_effect = _mock_getaddrinfo("93.184.216.34", "127.0.0.1")
+        with pytest.raises(SSRFBlocked):
+            _resolve_safe_ip("rebind.example", 80, 10.0)
+
+    @patch("initrunner.agent._urls.socket.getaddrinfo")
+    def test_picks_first_public_ip(self, mock_dns):
+        mock_dns.side_effect = _mock_getaddrinfo("93.184.216.34", "93.184.216.35")
+        assert _resolve_safe_ip("ok.example", 80, 10.0) == "93.184.216.34"


### PR DESCRIPTION
## Summary

`SSRFSafeTransport` validated the URL (its own `getaddrinfo`) and then handed off to httpx, which **re-resolved and connected** independently. A rebinding DNS resolver could return a public IP for the validation lookup and a private one (e.g. `169.254.169.254`, `127.0.0.1`) for the connect — a classic TOCTOU bypass.

## Changes (`agent/_urls.py`)

- **Pin the validated IP.** `_resolve_safe_ip()` resolves once and returns a single validated public IP. `_pin_request()` rewrites the request URL to that IP while preserving the original `Host` header and setting the TLS `sni_hostname` extension (httpcore uses it as `server_hostname`), so certificate verification still targets the hostname. httpx now connects to the exact IP we validated — no second resolution — and this runs **per redirect hop** for both the sync and async transports.
- **Widen `_BLOCKED_NETWORKS`:** `100.64.0.0/10` (CGNAT — contains Alibaba metadata `100.100.100.200`), `192.0.0.0/24`, `192.0.2.0/24`, `198.18.0.0/15`, `198.51.100.0/24`, `203.0.113.0/24`, `240.0.0.0/4` (incl. broadcast `255.255.255.255`), plus IPv6 `::/128` and `2001:db8::/32`.

## `mcp/browser.py`

`_check_url` is documented as a best-effort pre-check, **not** a containment boundary: `agent-browser` does its own DNS + fetch (and follows in-page navigation/redirects), so the real fix is running it inside a network-namespaced sandbox with egress filtering. (That sandbox work is tracked separately.)

## Testing

- `tests/test_urls.py` (40 passed): new coverage for the expanded CIDRs, `_resolve_safe_ip` (literal/private/mixed/first-public), and that the transport pins the validated IP with `Host` + `sni_hostname` preserved and blocks non-http schemes without a DNS lookup. Manually verified end-to-end against a local server (correct Host preserved; rebind-to-private and metadata blocked).
- Downstream `test_html` / `test_api_tools` / `test_mcp_browser` / `test_tools` pass. `ruff` + `ty` clean.

Found during a security audit; part of a series of hardening PRs.