### PR TITLE
fix: close audit-hook sandbox gaps, allowlist Docker args, honest sandbox docs

### DIFF
--- a/docs/security/sandbox.md
+++ b/docs/security/sandbox.md
@@ -85,7 +85,7 @@ For when a microVM checkbox is the actual question, see [Sandbox Backend Compari
 
 Mounts fall into two categories:
 
-- **User-configured** (`allowed_read_paths`, `allowed_write_paths`, `bind_mounts` from role YAML): validated at load time against the role's permitted roots. A typo'd `/etc` mount fails before the role ever runs.
+- **User-configured** (`allowed_read_paths`, `allowed_write_paths`, `bind_mounts` from role YAML): at **load time**, the schema refuses any *writable* bind whose source is a host system root (`/`, `/etc`, `/usr`, `/home`, ...), so a role can't hand the agent the host filesystem. Relative sources are confined to the role directory by the backend at **build time**. Read-only binds of system paths are permitted (they cannot write the host).
 - **Tool-internal** (e.g. `python_exec` writes code to `/tmp` and mounts it at `/work/_run.py`): code-controlled, trusted, no validation.
 
 ## Audit

--- a/docs/security/security.md
+++ b/docs/security/security.md
@@ -253,7 +253,9 @@ A blocked import raises `ValueError` and the agent fails to load.
 
 #### PEP 578 Audit Hook Sandbox
 
-AST analysis catches static import patterns, but a tool can trivially defeat it at runtime with string concatenation, `getattr`, or indirect imports. With `audit_hooks_enabled: true`, InitRunner installs a [PEP 578](https://peps.python.org/pep-0578/) audit hook that fires at the C-interpreter level on every `open()`, `socket.connect()`, `subprocess.Popen()`, `import`, `exec`, and `compile` -- regardless of how the call reached it. Python code can't bypass or remove an audit hook.
+AST analysis catches static import patterns, but a tool can trivially defeat it at runtime with string concatenation, `getattr`, or indirect imports. With `audit_hooks_enabled: true`, InitRunner installs a [PEP 578](https://peps.python.org/pep-0578/) audit hook that fires at the C-interpreter level on `open()`, `socket.connect()`, process-spawning calls (`subprocess.Popen`, `os.system`, `os.posix_spawn`, `os.exec*`, `os.fork`), `import`, `exec`, and `compile`.
+
+> **Limitation -- defense in depth, not containment.** An audit hook *cannot* be removed, but it does **not** contain code running in the same interpreter. Such code can re-acquire builtins, mutate this module's per-thread state, or call the internal framework-bypass helper to turn enforcement off, and the C-level event surface has gaps (a new syscall, a primitive without an audit event). Treat audit hooks as a tripwire and a speed bump for honest-but-buggy tools and prompt-injection noise -- **not** as a boundary against a determined adversary. For untrusted code (a malicious role/bundle, or prompt-injected `python`/`custom` tools), the real boundary is the [runtime sandbox](sandbox.md) (bwrap or Docker), which runs the code in a separate process under kernel isolation.
 
 ```yaml
 security:
@@ -279,8 +281,8 @@ security:
 
 | Event | Behavior |
 |-------|----------|
-| `open` (write mode) | Blocked unless path is in `allowed_write_paths`. Reads are always allowed. |
-| `subprocess.Popen`, `os.system` | Blocked unless `allow_subprocess: true`. |
+| `open` (write mode) | Blocked unless path is in `allowed_write_paths`. Reads are always allowed. Write intent is decoded from both the `open()` mode string and `os.open()` integer flags. |
+| `subprocess.Popen`, `os.system`, `os.posix_spawn`, `os.exec*`, `os.fork`, `os.forkpty` | Blocked unless `allow_subprocess: true`. |
 | `socket.connect` | Blocks connections to private IPs (RFC 1918, loopback, link-local) when `block_private_ips: true`. |
 | `socket.getaddrinfo` | Enforces `allowed_network_hosts` hostname allowlist at DNS resolution. |
 | `import` | Blocks modules in `blocked_custom_modules`. Always blocks `threading` and `_thread` (prevents sandbox escape via new threads). |

--- a/initrunner/agent/executor.py
+++ b/initrunner/agent/executor.py
@@ -89,6 +89,13 @@ def _prepare_run(
     """
     run_id = generate_id()
 
+    # Persist sandbox-hook violations to the audit chain. set_audit_logger is
+    # otherwise never called, so violations were only logged, never recorded.
+    if audit_logger is not None and role.spec.security.tools.audit_hooks_enabled:
+        from initrunner.agent.sandbox import set_audit_logger
+
+        set_audit_logger(audit_logger)
+
     blocked: RunResult | None = None
     if not skip_input_validation:
         blocked = _validate_input_or_fail(

--- a/initrunner/agent/runtime_sandbox/__init__.py
+++ b/initrunner/agent/runtime_sandbox/__init__.py
@@ -7,6 +7,7 @@ isolation (bubblewrap, Docker) for tool subprocesses.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from initrunner.agent.runtime_sandbox.base import (
@@ -22,7 +23,26 @@ if TYPE_CHECKING:
     from initrunner.audit.logger import AuditLogger
     from initrunner.audit.null import NullAuditLogger
 
+_logger = logging.getLogger(__name__)
+
 _default_audit: AuditLogger | NullAuditLogger | None = None
+
+
+def warn_if_unsandboxed(backend: object, tool_name: str) -> None:
+    """Warn once at build time when an exec tool will run on the host.
+
+    With ``security.sandbox.backend: none`` (the default), shell/python/script
+    tools execute model-generated commands with this process's own privileges.
+    That is a deliberate opt-out, but it should be visible -- real isolation
+    needs ``backend: bwrap`` or ``docker``.
+    """
+    if getattr(backend, "name", None) == "none":
+        _logger.warning(
+            "Tool %r runs on the host with no sandbox (security.sandbox.backend: none); "
+            "model-driven commands execute with this process's privileges. Set "
+            "security.sandbox.backend to 'bwrap' or 'docker' to contain them.",
+            tool_name,
+        )
 
 
 def set_default_audit_logger(audit: AuditLogger | NullAuditLogger | None) -> None:
@@ -48,4 +68,5 @@ __all__ = [
     "get_default_audit_logger",
     "resolve_backend",
     "set_default_audit_logger",
+    "warn_if_unsandboxed",
 ]

--- a/initrunner/agent/sandbox.py
+++ b/initrunner/agent/sandbox.py
@@ -4,12 +4,22 @@ Installs a permanent sys.addaudithook that enforces filesystem, network,
 subprocess, import, and eval/exec restrictions when a sandbox_scope() is active.
 Enforcement is per-thread via threading.local() — only fires inside custom tool
 invocations, never during framework operations.
+
+SCOPE / LIMITATION: this is defense-in-depth, NOT a containment boundary. Code
+running in the same interpreter can defeat an audit-hook sandbox -- e.g. by
+re-acquiring builtins, mutating this module's thread-local state, or calling the
+internal bypass helper. Audit hooks observe events; they cannot revoke a
+determined in-process adversary's access. For untrusted code, the real boundary
+is the runtime sandbox (bwrap/docker) that runs it in a separate process with
+kernel-level isolation. Keep the docs honest about this (see
+docs/security/security.md).
 """
 
 from __future__ import annotations
 
 import ipaddress
 import logging
+import os
 import sys
 import threading
 from contextlib import contextmanager
@@ -159,15 +169,37 @@ def _record_violation(state: _SandboxState, event: str, detail: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+# Bits in the os.open() flags int that imply write intent.
+_WRITE_FLAG_MASK = (
+    os.O_WRONLY | os.O_RDWR | os.O_CREAT | os.O_APPEND | os.O_TRUNC | getattr(os, "O_EXCL", 0)
+)
+
+
+def _open_is_write(args: tuple[Any, ...]) -> bool:
+    """Decide whether an 'open' audit event represents a write.
+
+    The PEP 578 ``open`` event carries ``(path, mode, flags)``. The builtin
+    ``open()`` sets *mode* to a string; ``os.open(path, flags)`` sets *mode* to
+    ``None`` and puts the intent in the integer *flags* (args[2]). The original
+    check bailed whenever *mode* was not a string, so ``os.open`` slipped past
+    the write-path allowlist entirely -- decode the flags instead.
+    """
+    mode = args[1] if len(args) >= 2 else None
+    if isinstance(mode, str):
+        return not set(mode) <= {"r", "b", "t"}
+    flags = args[2] if len(args) >= 3 else None
+    if isinstance(flags, int):
+        return bool(flags & _WRITE_FLAG_MASK)
+    # Unknown shape -> treat as a write so we fail closed rather than open.
+    return True
+
+
 def _check_open(state: _SandboxState, args: tuple[Any, ...]) -> None:
     """Check open() calls — block writes outside allowed paths, reads always pass."""
-    if len(args) < 2:
+    if len(args) < 1:
         return
-    path_arg, mode = args[0], args[1]
-    if not isinstance(mode, str):
-        return
-    # Read-only modes are always allowed
-    if set(mode) <= {"r", "b", "t"}:
+    path_arg = args[0]
+    if not _open_is_write(args):
         return
 
     # Write mode — check against allowed_write_paths
@@ -195,6 +227,22 @@ def _check_open(state: _SandboxState, args: tuple[Any, ...]) -> None:
             continue
 
     _record_violation(state, "open", f"Write to '{target}' blocked (not in allowed_write_paths)")
+
+
+# Every audit event that spawns or replaces a process. Checking only
+# subprocess.Popen / os.system left os.posix_spawn, os.exec*, os.spawn*, and
+# os.fork (which pty.fork uses) as open holes around allow_subprocess=False.
+_SUBPROCESS_EVENTS = frozenset(
+    {
+        "subprocess.Popen",
+        "os.system",
+        "os.exec",
+        "os.posix_spawn",
+        "os.spawn",
+        "os.fork",
+        "os.forkpty",
+    }
+)
 
 
 def _check_subprocess(state: _SandboxState, event: str) -> None:
@@ -331,7 +379,7 @@ def _audit_hook(event: str, args: tuple[Any, ...]) -> None:
 
     if event == "open":
         _check_open(state, args)
-    elif event in ("subprocess.Popen", "os.system"):
+    elif event in _SUBPROCESS_EVENTS:
         _check_subprocess(state, event)
     elif event == "socket.connect":
         _check_network(state, args)

--- a/initrunner/agent/schema/security.py
+++ b/initrunner/agent/schema/security.py
@@ -237,20 +237,57 @@ class ToolSandboxConfig(BaseModel):
     sandbox_violation_action: Literal["raise", "log"] = "raise"
 
 
-_DOCKER_BLOCKED_ARGS = frozenset(
+# Allowlist of Docker `docker run` flags safe to pass through extra_args. A
+# denylist is unwinnable here: the previous one missed -v/--volume/--mount, the
+# space-separated `--pid host` form, --gpus, --cgroup-parent, etc. -- any of
+# which escapes the container. Only resource/limit/label flags that cannot mount
+# host paths, share host namespaces, add capabilities/devices, or change the
+# runtime are permitted. Use the `flag=value` form for negative values.
+_DOCKER_ALLOWED_ARGS = frozenset(
     {
-        "--privileged",
-        "--cap-add",
-        "--security-opt",
-        "--pid=host",
-        "--userns=host",
-        "--network=host",
-        "--ipc=host",
-        "--uts=host",
-        "--device",
-        "--volume-driver",
-        "--runtime",
+        "--ulimit",
+        "--memory-swap",
+        "--memory-reservation",
+        "--memory-swappiness",
+        "--cpu-shares",
+        "--cpu-period",
+        "--cpu-quota",
+        "--cpus",
+        "--cpuset-cpus",
+        "--cpuset-mems",
+        "--pids-limit",
+        "--shm-size",
+        "--oom-kill-disable",
+        "--oom-score-adj",
+        "--stop-signal",
+        "--stop-timeout",
+        "--label",
+        "-l",
+        "--read-only",
+        "--tmpfs",
     }
+)
+
+# Absolute paths that must never be a *writable* bind-mount source: binding any
+# of these (or "/") read-write hands the agent the host filesystem.
+_DANGEROUS_WRITE_ROOTS = (
+    "/",
+    "/etc",
+    "/root",
+    "/home",
+    "/boot",
+    "/sys",
+    "/proc",
+    "/dev",
+    "/usr",
+    "/bin",
+    "/sbin",
+    "/lib",
+    "/lib64",
+    "/var",
+    "/run",
+    "/opt",
+    "/srv",
 )
 
 
@@ -287,11 +324,20 @@ class DockerBackendConfig(BaseModel):
 
     @field_validator("extra_args")
     @classmethod
-    def _reject_dangerous_args(cls, v: list[str]) -> list[str]:
+    def _allowlist_args(cls, v: list[str]) -> list[str]:
         for arg in v:
-            normalized = arg.split("=")[0] if "=" in arg else arg
-            if arg in _DOCKER_BLOCKED_ARGS or normalized in _DOCKER_BLOCKED_ARGS:
-                raise ValueError(f"Docker extra_arg '{arg}' is blocked for security reasons")
+            # Value tokens (e.g. the "nofile=1024" after "--ulimit") don't start
+            # with "-"; they belong to a preceding allowed flag.
+            if not arg.startswith("-"):
+                continue
+            name = arg.split("=", 1)[0]
+            if name not in _DOCKER_ALLOWED_ARGS:
+                raise ValueError(
+                    f"Docker extra_arg '{arg}' is not allowed. Permitted flags: "
+                    f"{sorted(_DOCKER_ALLOWED_ARGS)}. Mounts, host namespaces, "
+                    f"capabilities, devices, and runtime overrides are blocked to "
+                    f"preserve container isolation."
+                )
         return v
 
 
@@ -344,6 +390,43 @@ class SandboxConfig(BaseModel):
             )
         if len(targets) != len(set(targets)):
             raise ValueError("duplicate bind_mount targets")
+        return self
+
+    @model_validator(mode="after")
+    def _reject_dangerous_writable_mounts(self) -> SandboxConfig:
+        """Refuse writable binds of host system roots.
+
+        Binding "/" (or /etc, /usr, /home, ...) read-write into the sandbox hands
+        the agent the host filesystem -- defeating the isolation entirely. Only
+        absolute sources are checked here; role-relative paths are confined to
+        role_dir by the backend at build time. Read-only binds are allowed (they
+        cannot be used to write the host).
+        """
+        if self.backend == "ssh":
+            # SSH rejects bind_mounts / allowed_*_paths outright (see
+            # _validate_ssh_constraints); let that give the clearer message.
+            return self
+
+        from pathlib import Path
+
+        def _check(src: str, label: str) -> None:
+            p = Path(src)
+            if not p.is_absolute():
+                return
+            resolved = p.resolve()
+            for root in _DANGEROUS_WRITE_ROOTS:
+                r = Path(root)
+                if resolved == r or r.is_relative_to(resolved):
+                    raise ValueError(
+                        f"{label} '{src}' exposes host system path '{root}' as writable; "
+                        f"refused. Bind a specific project subdirectory instead."
+                    )
+
+        for m in self.bind_mounts:
+            if not m.read_only:
+                _check(m.source, "writable bind_mount source")
+        for w in self.allowed_write_paths:
+            _check(w, "allowed_write_path")
         return self
 
     @model_validator(mode="after")

--- a/initrunner/agent/tools/python_exec.py
+++ b/initrunner/agent/tools/python_exec.py
@@ -57,7 +57,10 @@ _PROXY_ENV_KEYS = (
 @register_tool("python", PythonToolConfig)
 def build_python_toolset(config: PythonToolConfig, ctx: ToolBuildContext) -> FunctionToolset:
     """Build a FunctionToolset for executing Python code in a subprocess."""
+    from initrunner.agent.runtime_sandbox import warn_if_unsandboxed
+
     backend = ctx.sandbox_backend
+    warn_if_unsandboxed(backend, "python")
     sandbox_cfg = ctx.role.spec.security.sandbox
 
     toolset = FunctionToolset()

--- a/initrunner/agent/tools/script.py
+++ b/initrunner/agent/tools/script.py
@@ -144,7 +144,10 @@ def _make_script_fn(
 @register_tool("script", ScriptToolConfig)
 def build_script_toolset(config: ScriptToolConfig, ctx: ToolBuildContext) -> FunctionToolset:
     """Build a FunctionToolset from a ScriptToolConfig."""
+    from initrunner.agent.runtime_sandbox import warn_if_unsandboxed
+
     backend = ctx.sandbox_backend
+    warn_if_unsandboxed(backend, "script")
 
     if config.working_dir:
         work_dir = Path(config.working_dir).resolve()

--- a/initrunner/agent/tools/shell.py
+++ b/initrunner/agent/tools/shell.py
@@ -78,7 +78,18 @@ def validate_command(
 @register_tool("shell", ShellToolConfig)
 def build_shell_toolset(config: ShellToolConfig, ctx: ToolBuildContext) -> FunctionToolset:
     """Build a FunctionToolset for executing commands (no shell)."""
+    from initrunner.agent.runtime_sandbox import warn_if_unsandboxed
+
     backend = ctx.sandbox_backend
+    warn_if_unsandboxed(backend, "shell")
+    if not config.allowed_commands:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "Shell tool has an empty allowed_commands list: every binary is permitted "
+            "(an interpreter like 'sh -c ...' re-enables a full shell). Set "
+            "allowed_commands to the specific binaries the agent needs."
+        )
 
     if config.working_dir:
         work_dir = Path(config.working_dir).resolve()

--- a/tests/test_audit_hooks.py
+++ b/tests/test_audit_hooks.py
@@ -261,6 +261,93 @@ class TestSubprocessHooks:
             stdout, _ = proc.communicate()
             assert b"test" in stdout
 
+    @pytest.mark.parametrize("event", ["os.posix_spawn", "os.exec", "os.fork", "os.forkpty"])
+    def test_process_spawn_events_blocked(self, event):
+        """os.posix_spawn / os.exec* / os.fork were unguarded -- only Popen/system were checked."""
+        from initrunner.agent.sandbox import _audit_hook
+
+        config = ToolSandboxConfig(audit_hooks_enabled=True, allow_subprocess=False)
+        state = _get_state()
+        state.enforcing = True
+        state.config = config
+        state.agent_name = "test"
+        try:
+            with pytest.raises(SandboxViolation, match="Subprocess execution blocked"):
+                _audit_hook(event, ("/bin/echo", ["echo"], {}))
+        finally:
+            state.enforcing = False
+            state.config = None
+
+    @pytest.mark.parametrize("event", ["os.posix_spawn", "os.fork"])
+    def test_process_spawn_events_allowed_when_enabled(self, event):
+        from initrunner.agent.sandbox import _audit_hook
+
+        config = ToolSandboxConfig(audit_hooks_enabled=True, allow_subprocess=True)
+        state = _get_state()
+        state.enforcing = True
+        state.config = config
+        state.agent_name = "test"
+        try:
+            _audit_hook(event, ("/bin/echo", ["echo"], {}))  # no raise
+            assert state.violations == []
+        finally:
+            state.enforcing = False
+            state.config = None
+
+
+# ---------------------------------------------------------------------------
+# Write-intent decoding (builtin open mode string vs os.open integer flags)
+# ---------------------------------------------------------------------------
+
+
+class TestOpenWriteDecoding:
+    def test_builtin_mode_string(self):
+        from initrunner.agent.sandbox import _open_is_write
+
+        assert _open_is_write(("/p", "w")) is True
+        assert _open_is_write(("/p", "wb")) is True
+        assert _open_is_write(("/p", "a")) is True
+        assert _open_is_write(("/p", "r+")) is True
+        assert _open_is_write(("/p", "r")) is False
+        assert _open_is_write(("/p", "rb")) is False
+
+    def test_os_open_integer_flags(self):
+        import os
+
+        from initrunner.agent.sandbox import _open_is_write
+
+        # os.open passes mode=None and the intent in args[2] (the int flags).
+        assert _open_is_write(("/p", None, os.O_WRONLY | os.O_CREAT)) is True
+        assert _open_is_write(("/p", None, os.O_RDWR)) is True
+        assert _open_is_write(("/p", None, os.O_APPEND | os.O_WRONLY)) is True
+        assert _open_is_write(("/p", None, os.O_RDONLY)) is False
+
+    def test_os_open_write_blocked_in_scope(self, tmp_path):
+        import os
+
+        config = ToolSandboxConfig(
+            audit_hooks_enabled=True,
+            allowed_write_paths=[],
+            sandbox_violation_action="raise",
+        )
+        with sandbox_scope(config=config, agent_name="test"):
+            with pytest.raises(SandboxViolation, match="open"):
+                os.open(str(tmp_path / "x.txt"), os.O_WRONLY | os.O_CREAT, 0o600)
+
+    def test_os_open_readonly_allowed_in_scope(self, tmp_path):
+        import os
+
+        target = tmp_path / "r.txt"
+        target.write_text("hi", encoding="utf-8")
+        config = ToolSandboxConfig(
+            audit_hooks_enabled=True,
+            allowed_write_paths=[],
+            sandbox_violation_action="raise",
+        )
+        with sandbox_scope(config=config, agent_name="test"):
+            fd = os.open(str(target), os.O_RDONLY)  # read -> allowed
+            os.close(fd)
+
 
 # ---------------------------------------------------------------------------
 # Import hooks

--- a/tests/test_docker_sandbox.py
+++ b/tests/test_docker_sandbox.py
@@ -10,7 +10,6 @@ import pytest
 
 from initrunner.agent._subprocess import SubprocessTimeout
 from initrunner.agent.schema.security import (
-    _DOCKER_BLOCKED_ARGS,
     BindMount,
     DockerBackendConfig,
     SandboxConfig,
@@ -122,18 +121,33 @@ class TestSandboxConfigValidation:
         with pytest.raises(ValueError):
             SandboxConfig(cpu_limit=-1.0)
 
-    def test_dangerous_extra_args_rejected(self):
-        for arg in _DOCKER_BLOCKED_ARGS:
-            with pytest.raises(ValueError, match="blocked for security"):
-                DockerBackendConfig(extra_args=[arg])
-
-    def test_dangerous_extra_args_with_value_rejected(self):
-        with pytest.raises(ValueError, match="blocked for security"):
-            DockerBackendConfig(extra_args=["--cap-add=ALL"])
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["--privileged"],
+            ["--cap-add=ALL"],
+            ["--cap-add", "SYS_ADMIN"],
+            ["-v", "/:/host"],
+            ["--volume", "/etc:/etc"],
+            ["--mount", "type=bind,src=/,dst=/host"],
+            ["--pid=host"],
+            ["--pid", "host"],  # space-separated form the old denylist missed
+            ["--network=host"],
+            ["--gpus", "all"],  # not in the old denylist
+            ["--device", "/dev/sda"],
+            ["--runtime=runsc"],
+            ["--cgroup-parent=/evil"],  # not in the old denylist
+        ],
+    )
+    def test_dangerous_extra_args_rejected(self, args):
+        with pytest.raises(ValueError, match="not allowed"):
+            DockerBackendConfig(extra_args=args)
 
     def test_safe_extra_args_allowed(self):
-        config = DockerBackendConfig(extra_args=["--pids-limit=100", "--ulimit=nofile=1024"])
-        assert len(config.extra_args) == 2
+        config = DockerBackendConfig(
+            extra_args=["--pids-limit=100", "--ulimit", "nofile=1024", "--cpus=2", "--read-only"]
+        )
+        assert len(config.extra_args) == 5
 
     def test_empty_image_rejected(self):
         with pytest.raises(ValueError, match="must not be empty"):
@@ -836,16 +850,16 @@ class TestDockerRuntimeField:
             DockerBackendConfig(runtime="bogus")  # type: ignore[arg-type]
 
     def test_extra_args_runtime_equals_form_rejected(self):
-        with pytest.raises(ValueError, match="blocked for security"):
+        with pytest.raises(ValueError, match="not allowed"):
             DockerBackendConfig(extra_args=["--runtime=runsc"])
 
     def test_extra_args_runtime_space_form_rejected(self):
-        with pytest.raises(ValueError, match="blocked for security"):
+        with pytest.raises(ValueError, match="not allowed"):
             DockerBackendConfig(extra_args=["--runtime", "runsc"])
 
     def test_extra_args_drift_now_blocked(self):
         for arg in ("--device", "--volume-driver", "--uts=host"):
-            with pytest.raises(ValueError, match="blocked for security"):
+            with pytest.raises(ValueError, match="not allowed"):
                 DockerBackendConfig(extra_args=[arg])
 
 
@@ -966,3 +980,36 @@ class TestDockerPreflightRuntime:
                     backend.preflight()
                     mock_subproc.assert_not_called()
                     mock_ensure.assert_called_once_with("python:3.12-slim")
+
+
+# ---------------------------------------------------------------------------
+# Writable bind-mount / allowed_write_paths containment
+# ---------------------------------------------------------------------------
+
+
+class TestWritableMountContainment:
+    @pytest.mark.parametrize("source", ["/", "/etc", "/usr", "/home", "/var", "/root"])
+    def test_writable_system_root_bind_rejected(self, source):
+        with pytest.raises(ValueError, match="host system path"):
+            SandboxConfig(bind_mounts=[BindMount(source=source, target="/host", read_only=False)])
+
+    @pytest.mark.parametrize("path", ["/", "/etc", "/usr"])
+    def test_allowed_write_path_system_root_rejected(self, path):
+        with pytest.raises(ValueError, match="host system path"):
+            SandboxConfig(allowed_write_paths=[path])
+
+    def test_readonly_system_bind_allowed(self):
+        cfg = SandboxConfig(bind_mounts=[BindMount(source="/etc", target="/etc", read_only=True)])
+        assert cfg.bind_mounts[0].read_only is True
+
+    def test_safe_writable_subdir_allowed(self):
+        cfg = SandboxConfig(allowed_write_paths=["/tmp/agent-workspace"])
+        assert cfg.allowed_write_paths == ["/tmp/agent-workspace"]
+
+    def test_relative_source_not_blocked_here(self):
+        # Relative paths are confined to role_dir by the backend at build time,
+        # not by this schema validator.
+        cfg = SandboxConfig(
+            bind_mounts=[BindMount(source="data", target="/work/data", read_only=False)]
+        )
+        assert cfg.bind_mounts[0].source == "data"


### PR DESCRIPTION
## Summary

The opt-in PEP 578 audit-hook sandbox had concrete bypasses, the Docker `extra_args` denylist was bypassable, and the docs oversold both as containment boundaries.

## In-process audit hook (`agent/sandbox.py`, `agent/executor.py`)

- **`os.open` write bypass:** `_check_open` bailed whenever the mode arg wasn't a string, so `os.open(path, O_WRONLY|O_CREAT)` (mode `None`, intent in the int flags) skipped `allowed_write_paths` entirely. It now decodes write intent from both the `open()` mode string and the `os.open()` flags.
- **Spawn bypass:** only `subprocess.Popen` / `os.system` were checked. `os.posix_spawn`, `os.exec*`, `os.fork`, `os.forkpty` (which `pty.fork` uses) are now blocked under `allow_subprocess: false`.
- **Violations never recorded:** `set_audit_logger()` was never called, so violations were only logged. The executor now wires it when audit hooks are enabled.
- **Honest docstring:** states plainly this is defense-in-depth, not containment for a determined in-process adversary.

## Runtime sandbox (`agent/schema/security.py`)

- **Docker `extra_args` → allowlist.** The exact-string denylist missed `-v`/`--volume`/`--mount`, the space-separated `--pid host` form, `--gpus`, `--cgroup-parent`, etc. — each a container escape. Only resource/label flags are now permitted; a value token following an allowed flag is accepted.
- **Writable system-root binds refused.** `SandboxConfig` rejects `allowed_write_paths` / writable `bind_mounts` whose source is a host system root (`/`, `/etc`, `/usr`, `/home`, ...). Read-only binds still allowed; relative paths confined to `role_dir` by the backend.

## Exec tools

- `shell` / `python` / `script` warn when built unsandboxed (`backend: none`); `shell` also warns on an empty `allowed_commands` list (every binary, including interpreters, is permitted).

## Docs

`security.md` and `sandbox.md` corrected: the "Python code can't bypass an audit hook" claim and the "mounts validated at load time against permitted roots" claim now match reality.

## Testing

`tests/test_audit_hooks.py`, `tests/test_docker_sandbox.py` (217 passed): write-intent decoding (mode string + `os.open` flags), `os.open` write blocked in scope, spawn-event blocking, the Docker allowlist (rejects `-v`/`--pid host`/`--gpus`/etc., accepts resource flags), and writable system-root containment. `ruff` + `ty` clean.

Found during a security audit; part of a series of hardening PRs.