### PR TITLE
test: clear get_home_dir() cache around every test (fix order-dependent failure)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,25 @@ def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool 
     return None
 
 
+@pytest.fixture(autouse=True)
+def _reset_home_dir_cache():
+    """Clear the get_home_dir() lru_cache around every test.
+
+    get_home_dir() is ``@lru_cache``'d but resolves from ``INITRUNNER_HOME`` /
+    ``XDG_DATA_HOME``. A test that monkeypatches those env vars populates the
+    cache with a temp path; monkeypatch then restores the env, but the cache
+    keeps the stale value for the rest of the session -- breaking any later test
+    that relies on the real home (e.g. store-path validation). Clearing before
+    and after each test keeps resolution consistent with the current env,
+    regardless of collection order.
+    """
+    from initrunner.config import get_home_dir
+
+    get_home_dir.cache_clear()
+    yield
+    get_home_dir.cache_clear()
+
+
 def make_role(
     *,
     name: str = "test-agent",


### PR DESCRIPTION
## Summary

`get_home_dir()` is `@lru_cache`'d but resolves from `INITRUNNER_HOME` / `XDG_DATA_HOME`. A test that `monkeypatch.setenv`s either var populates the cache with a temp path; monkeypatch restores the env afterward, but the `lru_cache` keeps the stale value for the rest of the session. Any later test that relies on the real home then fails.

Concretely, `tests/test_tool_sandbox.py::TestStorePathRestriction::test_path_under_initrunner_passes` passes in isolation but fails when collected after such a test — store-path validation saw the leaked temp home as `~/.initrunner` and rejected a path that was genuinely inside the real home.

## Fix

An autouse fixture in `tests/conftest.py` clears the cache before and after every test, so home resolution always reflects the current environment regardless of collection order. Every other `config.get_*` helper derives from `get_home_dir()`, so clearing this one cache covers them all.

## Testing

- The previously order-dependent selection now passes (`-k "sandbox or audit_hook or executor or shell or ... "`: 452 passed, was 451 + 1 failed).
- Full suite green: **5170 passed, 86 skipped**.