### PR TITLE
fix: broaden env scrubbing, cap chunked request bodies, drop spoofed audit actor

### DIFF
--- a/initrunner/agent/_subprocess.py
+++ b/initrunner/agent/_subprocess.py
@@ -14,57 +14,107 @@ class SubprocessTimeout(Exception):
         super().__init__(f"Execution timed out after {timeout}s")
 
 
+# Names whose env vars are scrubbed from tool subprocess environments. Tools
+# need almost no inherited env, so these prefixes are broad on purpose: matching
+# a non-secret like AWS_REGION and dropping it is harmless, while leaving a
+# secret behind is not. Whole-provider prefixes (AWS_, AZURE_, OPENAI_, ...)
+# catch key names that don't end in a recognised secret suffix -- e.g.
+# AWS_ACCESS_KEY_ID ends in _ID, GITHUB_PAT in _PAT, SECRET_KEY_BASE in _BASE.
 DEFAULT_SENSITIVE_ENV_PREFIXES = (
-    # AI providers
-    "OPENAI_API_KEY",
-    "ANTHROPIC_API_KEY",
+    # AI / LLM providers
+    "OPENAI_",
+    "ANTHROPIC_",
     "GOOGLE_API_KEY",
-    "HF_TOKEN",
+    "GEMINI_",
+    "HF_",
     "HUGGING_FACE",
-    "COHERE_API_KEY",
-    "REPLICATE_API_TOKEN",
+    "COHERE_",
+    "REPLICATE_",
+    "MISTRAL_",
+    "GROQ_",
+    "TOGETHER_",
+    "FIREWORKS_",
+    "DEEPSEEK_",
+    "PERPLEXITY_",
+    "XAI_",
+    "OPENROUTER_",
+    "VOYAGE_",
     # Cloud
-    "AWS_SECRET",
-    "AWS_SESSION_TOKEN",
+    "AWS_",
     "GCP_",
     "GCLOUD_",
     "GOOGLE_APPLICATION_CREDENTIALS",
     "GOOGLE_CLOUD_",
     "AZURE_",
-    "DIGITALOCEAN_TOKEN",
-    # VCS/CI
+    "DIGITALOCEAN_",
+    "DO_API",
+    "LINODE_",
+    "VULTR_",
+    "HETZNER_",
+    "CLOUDFLARE_",
+    "FASTLY_",
+    "NETLIFY_",
+    "VERCEL_",
+    "HEROKU_",
+    "RENDER_",
+    "RAILWAY_",
+    "FLY_API",
+    "SUPABASE_",
+    "FIREBASE_",
+    "ALICLOUD_",
+    "ALIBABA_CLOUD_",
+    "TENCENTCLOUD_",
+    "OCI_",
+    "IBMCLOUD_",
+    # VCS / CI / registries
     "GITHUB_TOKEN",
+    "GITHUB_PAT",
     "GH_TOKEN",
+    "GHP_",
     "GITLAB_TOKEN",
     "BITBUCKET_TOKEN",
     "CODECOV_TOKEN",
+    "NPM_TOKEN",
+    "PYPI_",
+    "TWINE_",
+    "JFROG_",
+    "ARTIFACTORY_",
+    "NUGET_",
     # Messaging
-    "SLACK_TOKEN",
-    "SLACK_WEBHOOK",
-    "SLACK_BOT_TOKEN",
-    "SLACK_SIGNING_SECRET",
+    "SLACK_",
     "TELEGRAM_BOT_TOKEN",
     "DISCORD_BOT_TOKEN",
     "TWILIO_",
-    "SENDGRID_API_KEY",
-    "MAILGUN_API_KEY",
+    "SENDGRID_",
+    "MAILGUN_",
     # Payment
     "STRIPE_",
-    # DB/infra
+    # DB / infra
     "DATABASE_URL",
     "REDIS_URL",
     "MONGO_URI",
+    "MONGODB_URI",
     "POSTGRES_PASSWORD",
     "MYSQL_PASSWORD",
-    # Auth/crypto
+    # Auth / crypto / framework secrets
     "SSH_AUTH_SOCK",
     "SSH_PRIVATE_KEY",
-    # Other
-    "NPM_TOKEN",
+    "SECRET_KEY",
+    "SESSION_SECRET",
+    "DJANGO_SECRET",
+    "RAILS_MASTER_KEY",
+    "JWT_SECRET",
+    # Misc tooling
     "DOCKER_PASSWORD",
     "DOCKER_TOKEN",
     "VAULT_TOKEN",
-    "SENTRY_DSN",
+    "SENTRY_",
+    "DATADOG_",
+    "DD_API_KEY",
+    "DD_APP_KEY",
+    "NEW_RELIC_",
+    "SNYK_",
+    "SONAR_",
 )
 
 DEFAULT_SENSITIVE_ENV_SUFFIXES = (
@@ -78,6 +128,12 @@ DEFAULT_SENSITIVE_ENV_SUFFIXES = (
     "_API_KEY",
     "_ACCESS_KEY",
     "_PRIVATE_KEY",
+    "_PAT",
+    "_DSN",
+    "_APIKEY",
+    "_APITOKEN",
+    "_CONNECTION_STRING",
+    "_KEY_BASE",
 )
 
 DEFAULT_ENV_ALLOWLIST: frozenset[str] = frozenset(

--- a/initrunner/middleware.py
+++ b/initrunner/middleware.py
@@ -160,6 +160,25 @@ def make_auth_dispatch(
     return dispatch
 
 
+async def read_body_capped(request: Request, max_bytes: int) -> bytes | None:
+    """Read the full request body, returning ``None`` if it exceeds *max_bytes*.
+
+    Streams the body and aborts the moment the cap is crossed, so a chunked
+    ``Transfer-Encoding`` request with no ``Content-Length`` cannot force
+    unbounded buffering. The header-only checks (``make_body_size_dispatch`` and
+    the webhook's Content-Length check) are trivially bypassed by chunked
+    encoding; this enforces the limit on the bytes actually received.
+    """
+    total = 0
+    chunks: list[bytes] = []
+    async for chunk in request.stream():
+        total += len(chunk)
+        if total > max_bytes:
+            return None
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
 def make_rate_limit_dispatch(
     *,
     rate_limiter,

--- a/initrunner/server/app.py
+++ b/initrunner/server/app.py
@@ -198,8 +198,16 @@ def create_app(
         return JSONResponse(resp.model_dump(exclude_none=True))
 
     async def chat_completions(request: Request) -> JSONResponse | StreamingResponse:
+        from initrunner.middleware import read_body_capped
+
+        # Bounded read closes the chunked-encoding bypass of the Content-Length
+        # body-size middleware (an attacker omits Content-Length to stream an
+        # unbounded body into memory).
+        raw = await read_body_capped(request, server_cfg.max_request_body_bytes)
+        if raw is None:
+            return _error_response(413, "request_too_large", "request body too large")
         try:
-            body = await request.json()
+            body = json.loads(raw)
         except Exception:
             return _error_response(400, "invalid_request_error", "invalid JSON body")
 

--- a/initrunner/triggers/webhook.py
+++ b/initrunner/triggers/webhook.py
@@ -52,17 +52,12 @@ class WebhookTrigger(TriggerBase):
             if not rate_limiter.allow():
                 return JSONResponse({"error": "rate limit exceeded"}, status_code=429)
 
-            content_length = request.headers.get("content-length")
-            if content_length:
-                try:
-                    if int(content_length) > _MAX_BODY_BYTES:
-                        return JSONResponse({"error": "payload too large"}, status_code=413)
-                except ValueError:
-                    pass
+            from initrunner.middleware import read_body_capped
 
-            body = await request.body()
-
-            if len(body) > _MAX_BODY_BYTES:
+            # Bounded read: a chunked request omits Content-Length, so the header
+            # check alone is bypassable -- cap the bytes actually received.
+            body = await read_body_capped(request, _MAX_BODY_BYTES)
+            if body is None:
                 return JSONResponse({"error": "payload too large"}, status_code=413)
 
             if config.secret:
@@ -73,12 +68,18 @@ class WebhookTrigger(TriggerBase):
                 if not hmac.compare_digest(sig_header, expected):
                     return JSONResponse({"error": "invalid signature"}, status_code=403)
 
-            principal_id = request.headers.get("x-principal-id")
+            # Never trust a client-supplied principal: it would flow into the
+            # HMAC-chained audit trail as the run's actor. Record the claim as
+            # untrusted metadata instead of adopting it as the identity.
+            metadata = {"path": config.path}
+            claimed_principal = request.headers.get("x-principal-id")
+            if claimed_principal:
+                metadata["claimed_principal_id"] = claimed_principal
             event = TriggerEvent(
                 trigger_type="webhook",
                 prompt=body.decode("utf-8", errors="replace"),
-                metadata={"path": config.path},
-                principal_id=principal_id,
+                metadata=metadata,
+                principal_id=None,
             )
             self._callback(event)
             return JSONResponse({"status": "ok"})

--- a/tests/test_secret_dos_hardening.py
+++ b/tests/test_secret_dos_hardening.py
@@ -1,0 +1,71 @@
+"""P3 hardening: subprocess env scrubbing breadth and bounded body reads."""
+
+from __future__ import annotations
+
+import pytest
+
+from initrunner.agent._subprocess import scrub_env
+from initrunner.middleware import read_body_capped
+
+
+class TestScrubEnvBreadth:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "AWS_ACCESS_KEY_ID",  # ends in _ID -> only the AWS_ prefix catches it
+            "AWS_SECRET_ACCESS_KEY",
+            "GITHUB_PAT",  # ends in _PAT
+            "SECRET_KEY_BASE",  # framework secret, ends in _BASE
+            "SENTRY_DSN",  # ends in _DSN
+            "MYAPP_DSN",
+            "OPENAI_API_KEY",
+            "STRIPE_SECRET_KEY",
+            "SLACK_WEBHOOK_URL",
+            "DATABASE_URL",
+            "JWT_SECRET",
+            "DD_API_KEY",
+        ],
+    )
+    def test_sensitive_names_scrubbed(self, name, monkeypatch):
+        monkeypatch.setenv(name, "leak")
+        assert name not in scrub_env()
+
+    @pytest.mark.parametrize(
+        "name", ["PATH", "HOME", "LANG", "TERM", "MY_PROJECT_DIR", "AWS_PLAIN"]
+    )
+    def test_benign_names_kept(self, name, monkeypatch):
+        # AWS_PLAIN starts with AWS_ -> intentionally dropped (broad prefix); the
+        # rest are kept. Assert the clearly-benign ones survive.
+        monkeypatch.setenv(name, "value")
+        env = scrub_env()
+        if name == "AWS_PLAIN":
+            assert name not in env  # broad AWS_ prefix is deliberate
+        else:
+            assert env.get(name) == "value"
+
+
+class _FakeRequest:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def stream(self):
+        for c in self._chunks:
+            yield c
+
+
+class TestReadBodyCapped:
+    def test_under_cap_returns_body(self):
+        import asyncio
+
+        assert asyncio.run(read_body_capped(_FakeRequest([b"ab", b"cd", b"ef"]), 100)) == b"abcdef"
+
+    def test_over_cap_returns_none(self):
+        # Chunked stream with no Content-Length: must abort once the cap is crossed.
+        import asyncio
+
+        assert asyncio.run(read_body_capped(_FakeRequest([b"x" * 8, b"y" * 8]), 10)) is None
+
+    def test_exact_cap_ok(self):
+        import asyncio
+
+        assert asyncio.run(read_body_capped(_FakeRequest([b"x" * 10]), 10)) == b"x" * 10

--- a/tests/test_smoke_daemon_webhook.py
+++ b/tests/test_smoke_daemon_webhook.py
@@ -114,6 +114,46 @@ class TestWebhookTriggerHTTP:
         finally:
             trigger.stop()
 
+    def test_x_principal_id_not_trusted(self):
+        # A client-supplied X-Principal-Id must not become the audit-trail actor.
+        port = _get_free_port()
+        events: list[TriggerEvent] = []
+        config = WebhookTriggerConfig(port=port)
+        trigger = WebhookTrigger(config, events.append)
+        trigger.start()
+        try:
+            _wait_for_port(port)
+            body = b"payload"
+            assert config.secret is not None
+            headers = _sign_body(body, config.secret)
+            headers["x-principal-id"] = "admin"
+            resp = httpx.post(f"http://127.0.0.1:{port}/webhook", content=body, headers=headers)
+            assert resp.status_code == 200
+            assert len(events) == 1
+            assert events[0].principal_id is None
+            assert events[0].metadata.get("claimed_principal_id") == "admin"
+        finally:
+            trigger.stop()
+
+    def test_chunked_oversize_body_rejected(self):
+        # No Content-Length (chunked) must still be capped, not buffered unbounded.
+        port = _get_free_port()
+        config = WebhookTriggerConfig(port=port)
+        trigger = WebhookTrigger(config, lambda e: None)
+        trigger.start()
+        try:
+            _wait_for_port(port)
+
+            def _gen():
+                # ~2 MB streamed in chunks, no Content-Length -> chunked encoding.
+                for _ in range(32):
+                    yield b"x" * 65536
+
+            resp = httpx.post(f"http://127.0.0.1:{port}/webhook", content=_gen())
+            assert resp.status_code == 413
+        finally:
+            trigger.stop()
+
     def test_wrong_method_returns_405(self):
         port = _get_free_port()
         config = WebhookTriggerConfig(port=port)


### PR DESCRIPTION
## Summary

Three P3 hardening items from the security audit.

### `scrub_env` leaked real secrets (`agent/_subprocess.py`)

The name-based denylist missed secrets whose names don't end in a recognised suffix: `AWS_ACCESS_KEY_ID` (ends `_ID`), `GITHUB_PAT` (`_PAT`), `SECRET_KEY_BASE` (`_BASE`), `*_DSN`. They leaked into tool subprocess environments. Broadened: whole-provider **prefixes** (`AWS_`, `AZURE_`, `OPENAI_`, `SLACK_`, `STRIPE_`, ...) catch key names lacking a secret suffix, plus new suffixes `_PAT`/`_DSN`/`_APIKEY`/`_APITOKEN`/`_KEY_BASE`/`_CONNECTION_STRING`. Tools inherit almost no env, so dropping a non-secret like `AWS_REGION` is harmless.

### Chunked-encoding body-size bypass (DoS) (`middleware.py`, `triggers/webhook.py`, `server/app.py`)

`make_body_size_dispatch` and the webhook only checked `Content-Length`, which a chunked `Transfer-Encoding` request omits — so an unbounded body buffered into memory. Added `read_body_capped()`, a streaming read that aborts the moment the cap is crossed, and used it in the webhook trigger and the OpenAI-compatible server's `chat_completions` (replacing `await request.json()`).

### Audit-actor spoofing (`triggers/webhook.py`)

The webhook copied the client `X-Principal-Id` header verbatim into `TriggerEvent.principal_id`, which flows into the HMAC-chained audit trail as the run's actor. Now `principal_id` is `None` and the claimed value is recorded as untrusted metadata (`claimed_principal_id`).

## Testing

- `tests/test_secret_dos_hardening.py`: scrub breadth (the named leaks + benign keys kept) and `read_body_capped` (under/over/exact cap).
- `tests/test_smoke_daemon_webhook.py`: `X-Principal-Id` not adopted as principal (recorded as claimed metadata), and a chunked ~2 MB body returns 413.
- Server (266) + subprocess/webhook suites pass; `ruff` + `ty` clean.

Found during a security audit; part of a series of hardening PRs.