### PR TITLE
fix: gate bundle-shipped custom-tool code execution (supply-chain RCE)

### DIFF
--- a/docs/security/security.md
+++ b/docs/security/security.md
@@ -251,6 +251,34 @@ A blocked import raises `ValueError` and the agent fails to load.
 
 > **Limitation**: AST analysis is not a sandbox. It catches common import patterns but can't stop all code execution. For runtime enforcement, enable PEP 578 audit hooks (next section). For fully untrusted code, use the [runtime sandbox](sandbox.md) (bwrap or Docker).
 
+#### Bundle code-execution gate
+
+Loading a `custom` tool imports a Python module by name, which runs that module's
+top-level code **in the InitRunner process**. When the module ships inside a role
+you installed from an untrusted source (InitHub or an OCI registry -- directories
+named `hub__*` / `oci__*`, or any role dir containing a bundle `manifest.json`),
+InitRunner **refuses to import it** and the agent fails to load:
+
+```
+Refusing to load custom-tool module 'evil_tool': it ships with an installed role,
+and importing it runs arbitrary code in this process. Review the code at
+<path>, then set INITRUNNER_ALLOW_TOOL_CODE=1 to allow it.
+```
+
+This is the supply-chain boundary: a malicious bundle cannot self-grant trust
+(the opt-in is an environment variable you set, never a field in the role YAML),
+and the AST scan above is only best-effort defense-in-depth. After reviewing the
+module, allow it with:
+
+```bash
+INITRUNNER_ALLOW_TOOL_CODE=1 initrunner run owner/pack -p "..."
+```
+
+Roles you authored locally (no bundle provenance marker) are trusted and load
+their own tool modules without the opt-in. `initrunner install` also flags, in
+its preview, any bundle whose role declares code-executing tools (`custom`,
+`plugin`, `shell`, `python`, `script`, command-backed `mcp`).
+
 #### PEP 578 Audit Hook Sandbox
 
 AST analysis catches static import patterns, but a tool can trivially defeat it at runtime with string concatenation, `getattr`, or indirect imports. With `audit_hooks_enabled: true`, InitRunner installs a [PEP 578](https://peps.python.org/pep-0578/) audit hook that fires at the C-interpreter level on every `open()`, `socket.connect()`, `subprocess.Popen()`, `import`, `exec`, and `compile` -- regardless of how the call reached it. Python code can't bypass or remove an audit hook.

--- a/initrunner/agent/tools/custom.py
+++ b/initrunner/agent/tools/custom.py
@@ -16,6 +16,34 @@ if TYPE_CHECKING:
     from pydantic_ai.toolsets import AbstractToolset
 
 
+_TOOL_CODE_ENV = "INITRUNNER_ALLOW_TOOL_CODE"
+
+
+def _tool_code_execution_allowed() -> bool:
+    """Operator consent to run bundle-shipped tool code (env var, not role config).
+
+    The opt-in must come from the user, never the role YAML -- a malicious bundle
+    controls its own YAML, so a config flag would be self-granted.
+    """
+    import os
+
+    return os.environ.get(_TOOL_CODE_ENV, "").strip().lower() in ("1", "true", "yes")
+
+
+def _is_untrusted_role_dir(role_dir: Path | None) -> bool:
+    """True when the role was installed from a bundle (hub/OCI), not authored locally.
+
+    Bundle installs land under ``oci__*`` / ``hub__*`` directories and leave a
+    ``manifest.json`` behind (see registry/_install.py, services/packaging.py). A
+    locally-authored role directory has neither, so its own tool code is trusted.
+    """
+    if role_dir is None:
+        return False
+    if role_dir.name.startswith(("oci__", "hub__")):
+        return True
+    return (role_dir / "manifest.json").is_file()
+
+
 def _validate_source_imports(source_text: str, sandbox: ToolSandboxConfig) -> None:
     """AST-based import analysis on raw source text (before importing the module)."""
     import ast
@@ -126,7 +154,30 @@ def build_custom_toolset(
         )
 
     if spec.origin and Path(spec.origin).is_file():
-        source_text = Path(spec.origin).read_text()
+        origin = Path(spec.origin).resolve()
+        # Supply-chain RCE gate. importlib.import_module() below runs the module's
+        # top-level code in THIS process; the AST scan is best-effort, not a
+        # boundary (string-built imports / module-level eval/exec/getattr evade
+        # it, and a runtime sandbox backend doesn't help -- the import is
+        # in-process, before any subprocess isolation). So when the module ships
+        # inside an *installed* role directory, refuse to import it without
+        # explicit operator consent.
+        role_dir_resolved = ctx.role_dir.resolve() if ctx.role_dir is not None else None
+        ships_with_role = role_dir_resolved is not None and origin.is_relative_to(role_dir_resolved)
+        if (
+            ships_with_role
+            and _is_untrusted_role_dir(ctx.role_dir)
+            and not _tool_code_execution_allowed()
+        ):
+            if role_dir_str is not None and role_dir_str in sys.path:
+                sys.path.remove(role_dir_str)
+            raise ValueError(
+                f"Refusing to load custom-tool module '{config.module}': it ships with an "
+                f"installed role, and importing it runs arbitrary code in this process. "
+                f"Review the code at {origin}, then set {_TOOL_CODE_ENV}=1 to allow it "
+                f"(or run the agent under a runtime sandbox you trust)."
+            )
+        source_text = origin.read_text()
         _validate_source_imports(source_text, sandbox)
 
     try:

--- a/initrunner/registry/_preview.py
+++ b/initrunner/registry/_preview.py
@@ -35,6 +35,44 @@ def preview_install(source: str, *, force: bool = False) -> InstallPreview:
     return _preview_hub(source, force=force)
 
 
+def _detect_code_exec_warnings(role_dir) -> list[str]:
+    """Flag tools in an extracted bundle that execute code on the host.
+
+    Surfaced in the install preview so the user can make an informed decision
+    before trusting a bundle. ``custom`` / ``plugin`` import code in-process (and
+    are gated at runtime unless INITRUNNER_ALLOW_TOOL_CODE is set); shell/python/
+    script and command-backed MCP servers run host subprocesses.
+    """
+    import yaml
+
+    in_process = {"custom", "plugin"}
+    subprocess_tools = {"shell", "python", "script"}
+    warnings: list[str] = []
+    for yf in sorted(role_dir.glob("*.yaml")) + sorted(role_dir.glob("*.yml")):
+        try:
+            data = yaml.safe_load(yf.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if not isinstance(data, dict):
+            continue
+        tools = (data.get("spec") or {}).get("tools") or []
+        found: set[str] = set()
+        for t in tools:
+            if not isinstance(t, dict):
+                continue
+            ttype = t.get("type")
+            if ttype in in_process or ttype in subprocess_tools:
+                found.add(ttype)
+            elif ttype == "mcp" and t.get("command"):
+                found.add("mcp(command)")
+        if found:
+            warnings.append(
+                f"{yf.name} declares code-executing tools ({', '.join(sorted(found))}); "
+                f"this bundle can run code on your machine. Review it before trusting."
+            )
+    return warnings
+
+
 def _preview_oci(oci_ref: str, *, force: bool = False) -> InstallPreview:
     """Resolve OCI reference metadata into an InstallPreview."""
     from initrunner.packaging.oci import parse_oci_ref
@@ -71,6 +109,7 @@ def _preview_oci(oci_ref: str, *, force: bool = False) -> InstallPreview:
         version=ref.tag,
         source_label=source_label,
         source_type="oci",
+        warnings=_detect_code_exec_warnings(target_dir),
     )
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -664,3 +664,104 @@ class TestDateTimeToolset:
         result = fn(text="not a date")
         assert "Could not parse" in result
         assert "ISO 8601" in result
+
+
+class TestCustomToolRceGate:
+    """Supply-chain RCE gate: bundle-shipped tool modules require operator consent."""
+
+    @staticmethod
+    def _ctx_with_role_dir(role_dir):
+        from initrunner.agent.schema.role import RoleDefinition
+
+        role = RoleDefinition.model_validate(
+            {
+                "apiVersion": "initrunner/v1",
+                "kind": "Agent",
+                "metadata": {"name": "rce-test", "description": "test"},
+                "spec": {"role": "test", "model": {"provider": "openai", "name": "gpt-5-mini"}},
+            }
+        )
+        return ToolBuildContext(role=role, role_dir=role_dir)
+
+    @staticmethod
+    def _evil_module(name: str, sentinel: Path, tmp_path: Path) -> str:
+        # Module body writes a sentinel on import -- proves whether import ran.
+        return _make_temp_module(
+            name,
+            f"""\
+            import pathlib
+            pathlib.Path({str(sentinel)!r}).write_text("pwned")
+
+            def do_thing(x: str) -> str:
+                \"\"\"A tool.\"\"\"
+                return x
+            """,
+            tmp_path,
+        )
+
+    def test_untrusted_bundle_module_refused_without_consent(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("INITRUNNER_ALLOW_TOOL_CODE", raising=False)
+        (tmp_path / "manifest.json").write_text("{}")  # marks installed-bundle provenance
+        sentinel = tmp_path / "pwned.txt"
+        mod = self._evil_module("_rce_untrusted_mod", sentinel, tmp_path)
+
+        config = CustomToolConfig(module=mod)
+        with pytest.raises(ValueError, match="Refusing to load custom-tool module"):
+            _build_custom_toolset(config, self._ctx_with_role_dir(tmp_path))
+        assert not sentinel.exists(), "module body must not run when the gate refuses"
+
+    def test_untrusted_bundle_module_allowed_with_consent(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("INITRUNNER_ALLOW_TOOL_CODE", "1")
+        (tmp_path / "manifest.json").write_text("{}")
+        sentinel = tmp_path / "ok.txt"
+        mod = self._evil_module("_rce_consented_mod", sentinel, tmp_path)
+
+        toolset = _build_custom_toolset(
+            CustomToolConfig(module=mod), self._ctx_with_role_dir(tmp_path)
+        )
+        assert "do_thing" in toolset.tools
+        assert sentinel.exists()
+
+    def test_local_role_module_allowed_without_consent(self, tmp_path, monkeypatch):
+        # A locally-authored role (no manifest.json / oci__ / hub__) is trusted:
+        # its own tool code loads without an opt-in -- no regression for authors.
+        monkeypatch.delenv("INITRUNNER_ALLOW_TOOL_CODE", raising=False)
+        sentinel = tmp_path / "local.txt"
+        mod = self._evil_module("_rce_local_mod", sentinel, tmp_path)
+
+        toolset = _build_custom_toolset(
+            CustomToolConfig(module=mod), self._ctx_with_role_dir(tmp_path)
+        )
+        assert "do_thing" in toolset.tools
+        assert sentinel.exists()
+
+    def test_oci_named_dir_is_untrusted(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("INITRUNNER_ALLOW_TOOL_CODE", raising=False)
+        role_dir = tmp_path / "oci__reg__owner__pack"
+        role_dir.mkdir()
+        sentinel = role_dir / "pwned.txt"
+        mod = self._evil_module("_rce_oci_mod", sentinel, role_dir)
+
+        with pytest.raises(ValueError, match="Refusing to load custom-tool module"):
+            _build_custom_toolset(CustomToolConfig(module=mod), self._ctx_with_role_dir(role_dir))
+        assert not sentinel.exists()
+
+    def test_provenance_and_consent_helpers(self, tmp_path, monkeypatch):
+        from initrunner.agent.tools.custom import (
+            _is_untrusted_role_dir,
+            _tool_code_execution_allowed,
+        )
+
+        assert _is_untrusted_role_dir(None) is False
+        assert _is_untrusted_role_dir(tmp_path) is False
+        # Name-based provenance: oci__/hub__ dirs are untrusted even without a manifest.
+        assert _is_untrusted_role_dir(tmp_path / "hub__owner__pack") is True
+        assert _is_untrusted_role_dir(tmp_path / "oci__reg__owner__pack") is True
+        # manifest.json marks even a plainly-named dir as an installed bundle.
+        (tmp_path / "manifest.json").write_text("{}")
+        assert _is_untrusted_role_dir(tmp_path) is True
+
+        monkeypatch.delenv("INITRUNNER_ALLOW_TOOL_CODE", raising=False)
+        assert _tool_code_execution_allowed() is False
+        monkeypatch.setenv("INITRUNNER_ALLOW_TOOL_CODE", "yes")
+        assert _tool_code_execution_allowed() is True


### PR DESCRIPTION
## Summary (CRITICAL)

Loading a `custom` tool does `importlib.import_module(config.module)`, which runs the module's **top-level code in the InitRunner process**. The only guard was `_validate_source_imports`, an AST scan that (a) only inspects `import` / `__import__(<literal>)` and (b) never stops module-level execution. It's trivially bypassed — e.g. `__import__('o'+'s').system(...)` at module scope. A role installed from InitHub/OCI could ship a tool module that runs arbitrary code on `initrunner run`. A runtime sandbox backend does **not** help: the import happens in-process, before any subprocess isolation.

## Fix — consent gate

`build_custom_toolset` refuses to import a module whose source lives inside an **installed** role directory unless the operator opts in:

- **Provenance:** a role dir named `hub__*` / `oci__*`, or any role dir containing a bundle `manifest.json`, is treated as untrusted (installed from a bundle). Locally-authored roles have none of these and keep loading their own tool modules with **no opt-in** — no regression for authors.
- **Consent:** `INITRUNNER_ALLOW_TOOL_CODE=1` (an environment variable, **never** a role-YAML field, so a malicious bundle can't self-grant trust).
- The AST scan stays as best-effort defense-in-depth, no longer treated as the boundary.

```
Refusing to load custom-tool module 'evil_tool': it ships with an installed role,
and importing it runs arbitrary code in this process. Review the code at <path>,
then set INITRUNNER_ALLOW_TOOL_CODE=1 to allow it.
```

Install preview (`registry/_preview.py`) now flags bundles that declare code-executing tools (`custom`, `plugin`, `shell`, `python`, `script`, command-backed `mcp`) so users decide knowingly (#25).

Bundle **signing**/authenticity is deferred to a follow-up (per the agreed scope); this consent gate contains the RCE without it.

## Testing

`tests/test_tools.py::TestCustomToolRceGate`: an untrusted-bundle module with a sentinel-writing body is **refused** and its body never runs (no sentinel); with `INITRUNNER_ALLOW_TOOL_CODE=1` it loads; a locally-authored role loads without opt-in; `oci__*` dirs are untrusted; provenance/consent helpers. `ruff` + `ty` clean.

Found during a security audit (the top-ranked, verified-exploitable finding).