### PR TITLE
deps: bump posthog-js from 1.386.6 to 1.393.4 in /dashboard

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -30,7 +30,7 @@
     "@dicebear/core": "^9.4.2",
     "@dicebear/rings": "^9.4.2",
     "@xyflow/svelte": "^1.6.0",
-    "posthog-js": "^1.386.6"
+    "posthog-js": "^1.393.4"
   },
   "pnpm": {
     "overrides": {

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(svelte@5.56.3)
       posthog-js:
-        specifier: ^1.386.6
-        version: 1.386.6
+        specifier: ^1.393.4
+        version: 1.393.4
     devDependencies:
       '@sveltejs/adapter-static':
         specifier: ^3.0.0
@@ -132,11 +132,11 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@posthog/core@1.32.3':
-    resolution: {integrity: sha512-vwOEMfZvGv5XxNWV7p9I52NSmvFNMhyW2IHpIoUHW5jLkgUrknzJW1H/qxVGSIrNNVQkfsoaDFzDhJdg10pgrA==}
+  '@posthog/core@1.37.3':
+    resolution: {integrity: sha512-Dvw4CTlRVH4K5ag/B8YIHgG4E27w43MCUsXpn1iKQHIggIMN3Shq9whG4Omm3OvXPF+VikBTmpyMKUjckPxw+g==}
 
-  '@posthog/types@1.386.3':
-    resolution: {integrity: sha512-LqJoiQi2eyWn7rCUgnn+D+F3Efp6+04o72bjSX6kWHx0nFaYNC/nJuAIRliDTY/X7GPIUAaHAcSjbMI/9wfX1Q==}
+  '@posthog/types@1.391.1':
+    resolution: {integrity: sha512-ASwd7Nf4pViqdYRYaNRyPYRVKWa1CcHUAUWR0XeQJLGdNnsWACBwe0sSieb/cHnKsRXjRwO/23KIY83lm/Ccpw==}
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -679,8 +679,8 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
-  posthog-js@1.386.6:
-    resolution: {integrity: sha512-xRcbToRtU07Ojk+VaCCos6I/zD60sNKfWxdeZih0xbncgegIqLZJmBzi4HdkSkXrf14b6HhwMI/s2GxWha5ADQ==}
+  posthog-js@1.393.4:
+    resolution: {integrity: sha512-mOBSVQczEfyLnW3aFRbLXZEuE0Rfbmhqm9UCnuLeMFUUz0uYTkbnyhl5+Uc+BLSGfyiXHLf3nm2BqxYC+G/PXA==}
 
   preact@10.29.2:
     resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
@@ -893,11 +893,11 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@posthog/core@1.32.3':
+  '@posthog/core@1.37.3':
     dependencies:
-      '@posthog/types': 1.386.3
+      '@posthog/types': 1.391.1
 
-  '@posthog/types@1.386.3': {}
+  '@posthog/types@1.391.1': {}
 
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
@@ -1313,10 +1313,10 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  posthog-js@1.386.6:
+  posthog-js@1.393.4:
     dependencies:
-      '@posthog/core': 1.32.3
-      '@posthog/types': 1.386.3
+      '@posthog/core': 1.37.3
+      '@posthog/types': 1.391.1
       core-js: 3.49.0
       dompurify: 3.4.10
       fflate: 0.4.8


### PR DESCRIPTION
Bumps posthog-js from 1.386.6 to 1.393.4 (latest) in `/dashboard`, plus its `@posthog/core` and `@posthog/types` transitives.

Done manually rather than via Dependabot: Dependabot is currently unable to resolve the dashboard JavaScript dependency files, so it could neither rebase nor recreate #163 (it failed both, with `Dependabot cant resolve your JavaScript dependency files`). The same resolution issue led Dependabot to auto-close the @sveltejs/kit PR #162 as superseded. The bump resolves cleanly with pnpm 10.32.1 locally, and `pnpm install --frozen-lockfile` passes.

Supersedes #163. No version release.