### PR TITLE
feat: always-on services CLI and collector catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,5 +218,5 @@ package-lock.json
 node_modules/
 .svelte-kit/
 
-# Dev role file
-role.yaml
+# Dev role file (repo root only — do not ignore packaged catalog roles)
+/role.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [2026.7.6] - 2026-07-30
+
+### Added
+- **Always-on services (`initrunner service`).** Curated agents you start once and operate without editing YAML: `list`, `info`, `start`, `status`, `run`, `stop`, `logs`. State lives under `~/.initrunner/services/<slug>/` with supervised daemons (Linux).
+- **Shipped `collector` service.** Scheduled monitoring for a target (search + web_reader + memory); start with e.g. `initrunner service start collector acme.com`. Requires `initrunner[search]` and a configured provider. Runtime agent name is `service-collector` so audit, memory, and budgets do not collide with a user role named `collector`.
+- **Operate-time safety:** slug path containment, process identity before signal (boot id + start ticks + cmdline), lifecycle file locks outside instance dirs, generationed instance roles, heal-to-stopped when the daemon is gone, and purge that does not touch audit/memory/budget.
+
+### Changed
+- **Root-only gitignore for `/role.yaml`.** The previous `role.yaml` rule ignored every file of that name (including packaged catalog roles). Catalog `role.yaml` files now ship in the wheel.
+
+### Docs
+- New guide: [Always-on Services](docs/agents/services.md); CLI reference and README pointer for `service` commands.
+
 ## [2026.7.5] - 2026-07-27
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,7 @@ The tag push triggers the release pipeline (PyPI publish + GitHub Release).
 | Creating, scaffolding (`tool new`) & hot-attaching (`--dev`) tools | `docs/agents/tool_creation.md` |
 | Tool registry internals | `docs/agents/registry.md` |
 | Skills (SKILL.md bundles) | `docs/agents/skills_feature.md` |
+| Always-on services (start/status/stop) | `docs/agents/services.md` |
 | Security model | `docs/security/security.md` |
 | Human-in-the-loop approval | `docs/security/approvals.md` |
 | Credential vault | `docs/security/vault.md` |

--- a/README.md
+++ b/README.md
@@ -182,17 +182,17 @@ Seven trigger types: cron, webhook, file_watch, heartbeat, telegram, discord, sl
 
 ### Always-on services
 
-For a curated outcome without writing YAML, use **services** — productized always-on agents with start/stop/status:
+When you want a **productized always-on outcome** without authoring YAML, use services instead of hand-rolling a daemon role. Start once, check status, force a tick, pause cleanly:
 
 ```bash
 initrunner service list
-initrunner service start collector acme.com    # needs initrunner[search] (Linux)
+initrunner service start collector acme.com    # Linux; needs initrunner[search]
 initrunner service status collector
-initrunner service run collector               # one tick now
-initrunner service stop collector
+initrunner service run collector               # one tick now (no waiting on cron)
+initrunner service stop collector              # --purge deletes local instance data
 ```
 
-State lives under `~/.initrunner/services/`. See [Always-on Services](docs/agents/services.md).
+Shipped first: **`collector`** (scheduled monitoring for a company, domain, or topic). Instance state lives under `~/.initrunner/services/`. See [Always-on Services](docs/agents/services.md).
 
 ### Autopilot
 
@@ -340,6 +340,7 @@ Also available as a native desktop window (`initrunner desktop`). See [Dashboard
 
 | Feature | Command / config | Docs |
 |---------|-----------------|------|
+| **Always-on services** (curated start/stop/status; no YAML) | `initrunner service start collector acme.com` | [Services](docs/agents/services.md) |
 | **Skills** (reusable tool + prompt bundles) | `spec: { skills: [../skills/web-researcher] }` | [Skills](docs/agents/skills_feature.md) |
 | **Tool scaffolding** (LLM-write a tool, hot-attach in the REPL with `--dev`) | `initrunner tool new "fetch a PR diff"` | [Tools](docs/agents/tool_creation.md) |
 | **Plan** (static dry-run: reachable tools, policies, sandbox, cost; no model call) | `initrunner plan role.yaml` | [Plan](docs/operations/plan.md) |
@@ -358,16 +359,17 @@ Also available as a native desktop window (`initrunner desktop`). See [Dashboard
 
 ```
 initrunner/
-  agent/        Role schema, loader, executor, self-registering tools
-  runner/       Single-shot, REPL, autonomous, daemon execution modes
-  flow/         Multi-agent orchestration via flow.yaml
-  triggers/     Cron, file watcher, webhook, heartbeat, Telegram, Discord
-  stores/       Document + memory stores (LanceDB, zvec)
-  ingestion/    Extract, chunk, embed, store pipeline
-  mcp/          MCP server integration and gateway
-  audit/        Append-only SQLite audit trail with secret scrubbing
-  services/     Shared business logic layer
-  cli/          Typer + Rich CLI entry point
+  agent/             Role schema, loader, executor, self-registering tools
+  runner/            Single-shot, REPL, autonomous, daemon execution modes
+  service_catalog/   Shipped always-on service templates (collector, …)
+  flow/              Multi-agent orchestration via flow.yaml
+  triggers/          Cron, file watcher, webhook, heartbeat, Telegram, Discord
+  stores/            Document + memory stores (LanceDB, zvec)
+  ingestion/         Extract, chunk, embed, store pipeline
+  mcp/               MCP server integration and gateway
+  audit/             Append-only SQLite audit trail with secret scrubbing
+  services/          Shared business logic (incl. always-on lifecycle)
+  cli/               Typer + Rich CLI entry point
 ```
 
 Built on [PydanticAI](https://ai.pydantic.dev/). See [CONTRIBUTING.md](CONTRIBUTING.md) for dev setup.
@@ -384,7 +386,7 @@ Built on [PydanticAI](https://ai.pydantic.dev/). See [CONTRIBUTING.md](CONTRIBUT
 |------|----------|
 | Getting started | [Installation](docs/getting-started/installation.md) · [Setup](docs/getting-started/setup.md) · [Tutorial](docs/getting-started/tutorial.md) · [CLI Reference](docs/getting-started/cli.md) |
 | Quickstarts | [RAG](docs/getting-started/rag-quickstart.md) · [Docker](docs/getting-started/docker.md) · [Discord Bot](docs/getting-started/discord.md) · [Telegram Bot](docs/getting-started/telegram.md) |
-| Agents & tools | [Tools](docs/agents/tools.md) · [Tool Creation](docs/agents/tool_creation.md) · [Tool Search](docs/core/tool-search.md) · [Skills](docs/agents/skills_feature.md) · [Providers](docs/configuration/providers.md) |
+| Agents & tools | [Tools](docs/agents/tools.md) · [Tool Creation](docs/agents/tool_creation.md) · [Tool Search](docs/core/tool-search.md) · [Skills](docs/agents/skills_feature.md) · [Always-on Services](docs/agents/services.md) · [Providers](docs/configuration/providers.md) |
 | Intelligence | [Reasoning](docs/core/reasoning.md) · [Intent Sensing](docs/core/intent_sensing.md) · [Autonomy](docs/orchestration/autonomy.md) · [Structured Output](docs/core/structured-output.md) |
 | Knowledge & memory | [Ingestion](docs/core/ingestion.md) · [Memory](docs/core/memory.md) · [Multimodal Input](docs/core/multimodal.md) |
 | Orchestration | [Patterns Guide](docs/orchestration/patterns-guide.md) · [Flow](docs/orchestration/flow.md) · [Delegation](docs/orchestration/delegation.md) · [Team Mode](docs/orchestration/team_mode.md) · [Triggers](docs/core/triggers.md) |

--- a/README.md
+++ b/README.md
@@ -180,6 +180,20 @@ spec:
 
 Seven trigger types: cron, webhook, file_watch, heartbeat, telegram, discord, slack. The daemon hot-reloads role changes without restarting and runs up to four triggers concurrently. See [Triggers](docs/core/triggers.md).
 
+### Always-on services
+
+For a curated outcome without writing YAML, use **services** — productized always-on agents with start/stop/status:
+
+```bash
+initrunner service list
+initrunner service start collector acme.com    # needs initrunner[search] (Linux)
+initrunner service status collector
+initrunner service run collector               # one tick now
+initrunner service stop collector
+```
+
+State lives under `~/.initrunner/services/`. See [Always-on Services](docs/agents/services.md).
+
 ### Autopilot
 
 `--autopilot` is `--daemon` plus the autonomous loop on every trigger. A Telegram message like "find me flights from NYC to London next week" in daemon mode gets one LLM turn. In autopilot, the agent searches flights, compares options, checks dates, and replies with a shortlist.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   English · <a href="README.zh-CN.md">简体中文</a> · <a href="README.ja.md">日本語</a>
 </p>
 
-Define an agent in one YAML file. Chat with it. When it works, let it run autonomously. When you trust it, deploy it as a daemon that reacts to cron schedules, file changes, webhooks, and Telegram messages. Same file the whole way. No rewrite between prototyping and production.
+Define an agent in one YAML file. Chat with it. When it works, let it run autonomously. When you trust it, deploy it as a daemon that reacts to cron schedules, file changes, webhooks, and Telegram messages. Same file the whole way. No rewrite between prototyping and production. Prefer a curated outcome without YAML? Use [always-on services](#always-on-services).
 
 ## Quickstart
 

--- a/docs/agents/services.md
+++ b/docs/agents/services.md
@@ -1,0 +1,106 @@
+# Always-on Services
+
+Services are **curated always-on agents**: start once, they run on a schedule, report status, and stop without requiring YAML. Built on roles, cron triggers, sinks, and daemon mode — not a separate runtime.
+
+**Prerequisites**
+
+- Linux (process supervision is Linux-only in v1)
+- A configured model provider (`initrunner setup` or env keys)
+- For `collector`: `pip install "initrunner[search]"`
+
+## Quick start
+
+```bash
+# See what's available
+initrunner service list
+
+# Start collector (needs initrunner[search] + a provider)
+initrunner service start collector acme.com
+
+# Or with explicit schedule / sink
+initrunner service start collector acme.com \
+  --every daily \
+  --sink file:./collector-report.md
+
+# Health
+initrunner service status collector
+
+# Force one cycle without waiting for cron
+initrunner service run collector
+
+# Stop (keep instance) or purge local files
+initrunner service stop collector
+initrunner service stop collector --purge
+```
+
+## Commands
+
+| Command | What it does |
+|---------|----------------|
+| `service list` | Catalog + local status |
+| `service info <slug>` | Params, requires, defaults |
+| `service start <slug> [primary]` | Materialize + start daemon |
+| `service status <slug>` | State, process health, last run, cost |
+| `service run <slug>` | One-shot tick (briefly stops daemon if running) |
+| `service stop [--purge]` | Stop daemon; `--purge` deletes instance dir |
+| `service logs <slug>` | Daemon log tail |
+
+### Start options
+
+| Flag | Meaning |
+|------|---------|
+| positional | Value for the service `primary_param` (e.g. `target`) |
+| `--set key=value` | Any declared param (duplicate keys rejected) |
+| `--every` | `hourly` / `daily` / `weekly` / raw 5-field cron |
+| `--sink file:/path` or `webhook:url` | Replace entire sink set (repeatable) |
+
+Do not pass the primary both as a positional and via `--set`.
+
+## Shipped services
+
+### `collector`
+
+Continuous monitoring for one target. Searches and reads public sources, diffs against memory, writes a brief when something material changes.
+
+| Param | Required | Default | Notes |
+|-------|----------|---------|-------|
+| `target` | yes | — | Company, person, domain, topic (primary) |
+| `alert_severity` | no | `medium` | `low` / `medium` / `high` |
+
+Default schedule: `daily` (06:00 UTC). Requires: `initrunner[search]`.
+
+Runtime agent name is `service-collector` (isolates audit, memory, and budgets from any role also named `collector`).
+
+## How it works
+
+1. **Catalog** — templates under `initrunner/service_catalog/<slug>/` (`service.yaml` + `role.yaml`).
+2. **Start** — validates params and requirements, writes a generationed instance role with `{{ params.* }}` filled, injects schedule/sinks, starts a supervised daemon.
+3. **Stop** — signals only a **verified** daemon process; instance config remains unless `--purge`.
+4. **Run** — one-shot tick; if the service was running, the daemon is stopped, the tick runs, then the daemon is restarted.
+
+```text
+~/.initrunner/services/<slug>/
+  state.json
+  role.<n>.yaml
+  daemon.log
+  data/                 # relative file sinks
+
+~/.initrunner/services/.locks/<slug>.lock   # never purged
+```
+
+## Purge scope
+
+`stop --purge` deletes instance configuration, logs, and file outputs under `~/.initrunner/services/<slug>/`. It does **not** delete:
+
+- global audit history
+- memory store data for `service-<slug>`
+- budget counters
+
+## v1 limits
+
+- Linux only for start / stop / run supervision
+- One instance per service slug
+- Agent entry only (no Flow services)
+- Per-service process (not a multi-service supervisor)
+- Sinks: `file:` and `webhook:` only
+- No reboot auto-start (re-run `service start` after reboot)

--- a/docs/getting-started/cli.md
+++ b/docs/getting-started/cli.md
@@ -71,6 +71,11 @@ This means `initrunner run .` works from inside an agent directory, and `initrun
 | `initrunner flow status <name>` | Show systemd service status |
 | `initrunner flow logs <name>` | Show journald logs |
 | `initrunner flow events` | Query delegate routing events |
+| `initrunner service list` | List curated always-on services ([guide](../agents/services.md)) |
+| `initrunner service start <slug> [primary]` | Start an always-on service (Linux) |
+| `initrunner service status <slug>` | Service health, last run, cost |
+| `initrunner service stop <slug>` | Stop a service (`--purge` deletes instance data) |
+| `initrunner service run <slug>` | Force one scheduled tick now |
 | `initrunner mcp list-tools <PATH>` | List tools from MCP servers in a role |
 | `initrunner mcp serve <PATH>...` | Expose agents as an MCP server |
 | `initrunner login` | Log in to InitHub (browser auth) or OCI registry |

--- a/initrunner/__main__.py
+++ b/initrunner/__main__.py
@@ -1,0 +1,6 @@
+"""Allow ``python -m initrunner …`` for service daemon children and scripting."""
+
+from initrunner.cli.main import app_entry
+
+if __name__ == "__main__":
+    app_entry()

--- a/initrunner/agent/schema/service.py
+++ b/initrunner/agent/schema/service.py
@@ -1,0 +1,146 @@
+"""Always-on service catalog schema (kind: Service)."""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from initrunner.agent.schema.base import ApiVersion, Metadata
+
+# CLI slug / instance directory name. Single segment only (no slashes).
+SERVICE_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
+ServiceName = Annotated[str, Field(pattern=SERVICE_NAME_RE.pattern)]
+
+
+class ServiceKind(StrEnum):
+    SERVICE = "Service"
+
+
+class ServiceParamType(StrEnum):
+    STRING = "string"
+    ENUM = "enum"
+    INT = "int"
+    BOOL = "bool"
+
+
+class ServiceParam(BaseModel):
+    """Start-time parameter declared by a service."""
+
+    type: ServiceParamType = ServiceParamType.STRING
+    required: bool = False
+    default: Any = None
+    description: str = ""
+    values: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _enum_requires_values(self) -> ServiceParam:
+        if self.type == ServiceParamType.ENUM and not self.values:
+            raise ValueError("enum params require a non-empty values list")
+        return self
+
+
+class ServiceEntry(BaseModel):
+    """What the service runs after start (Agent role only in v1)."""
+
+    kind: Literal["Agent"] = "Agent"
+    path: str = "role.yaml"
+
+
+class ServiceRequires(BaseModel):
+    """Hard requirements checked before start succeeds."""
+
+    env: list[str] = Field(default_factory=list)
+    extras: list[str] = Field(default_factory=list)
+
+
+class ServiceDefaults(BaseModel):
+    """Defaults applied when materializing the instance role."""
+
+    sinks: list[dict[str, Any]] = Field(default_factory=list)
+    guardrails: dict[str, Any] = Field(default_factory=dict)
+    timezone: str = "UTC"
+    autonomy: bool = False
+
+
+class ServiceSpec(BaseModel):
+    entry: ServiceEntry = ServiceEntry()
+    params: dict[str, ServiceParam] = Field(default_factory=dict)
+    primary_param: str | None = None
+    every: str = "daily"
+    defaults: ServiceDefaults = ServiceDefaults()
+    requires: ServiceRequires = ServiceRequires()
+    schedule_prompt: str = "Run the scheduled service task."
+
+    @model_validator(mode="after")
+    def _primary_param_valid(self) -> ServiceSpec:
+        if self.primary_param is None:
+            return self
+        if self.primary_param not in self.params:
+            raise ValueError(f"primary_param '{self.primary_param}' is not declared in params")
+        if not self.params[self.primary_param].required:
+            raise ValueError(f"primary_param '{self.primary_param}' must be a required parameter")
+        return self
+
+
+class ServiceDefinition(BaseModel):
+    """Root document for service.yaml."""
+
+    apiVersion: ApiVersion = ApiVersion.V1
+    kind: ServiceKind = ServiceKind.SERVICE
+    metadata: Metadata
+    spec: ServiceSpec
+
+    @field_validator("kind", mode="before")
+    @classmethod
+    def _coerce_kind(cls, v: object) -> object:
+        if isinstance(v, str) and v == "Service":
+            return ServiceKind.SERVICE
+        return v
+
+    @field_validator("metadata", mode="after")
+    @classmethod
+    def _slug_name(cls, meta: Metadata) -> Metadata:
+        if not SERVICE_NAME_RE.fullmatch(meta.name):
+            raise ValueError(f"Invalid service name '{meta.name}'")
+        return meta
+
+
+class ServiceStatus(StrEnum):
+    RUNNING = "running"
+    STOPPED = "stopped"
+
+
+class ProcessIdentity(BaseModel):
+    """Linux process identity evidence for a supervised daemon."""
+
+    pid: int
+    boot_id: str
+    proc_start_ticks: int
+    role_path: str
+    started_at: str | None = None  # display only
+
+
+class ServiceState(BaseModel):
+    """Runtime state for one started service instance (state.json)."""
+
+    slug: ServiceName
+    service_version: str = ""
+    status: ServiceStatus = ServiceStatus.STOPPED
+    params: dict[str, Any] = Field(default_factory=dict)
+    sinks: list[dict[str, Any]] = Field(default_factory=list)
+    every: str = "daily"
+    resolved_cron: str = ""
+    timezone: str = "UTC"
+    started_at: str | None = None  # first start wall clock (display)
+    stopped_at: str | None = None
+    generation: int = 0
+    role_file: str = ""  # e.g. role.1.yaml
+    role_digest: str = ""
+    state_version: int = 1
+    catalog_path: str = ""
+    process: ProcessIdentity | None = None
+    last_error: str | None = None
+    output_paths: list[str] = Field(default_factory=list)

--- a/initrunner/cli/main.py
+++ b/initrunner/cli/main.py
@@ -15,6 +15,7 @@ from initrunner.cli.flow_cmd import app as flow_app
 from initrunner.cli.hub_cmd import app as hub_app
 from initrunner.cli.mcp_cmd import app as mcp_app
 from initrunner.cli.memory_cmd import app as memory_app
+from initrunner.cli.service_cmd import app as service_app
 from initrunner.cli.skill_cmd import app as skill_app
 from initrunner.cli.telemetry_cmd import app as telemetry_app
 from initrunner.cli.tool_cmd import app as tool_app
@@ -211,6 +212,9 @@ app.command(rich_help_panel="Interfaces")(desktop)
 app.add_typer(a2a_app, name="a2a", rich_help_panel="Interfaces")
 app.add_typer(flow_app, name="flow", rich_help_panel="Interfaces")
 app.add_typer(mcp_app, name="mcp", rich_help_panel="Interfaces")
+
+# --- Always-on ---
+app.add_typer(service_app, name="service", rich_help_panel="Always-on")
 
 # --- Package Registry ---
 app.command(rich_help_panel="Package Registry")(install)

--- a/initrunner/cli/service_cmd.py
+++ b/initrunner/cli/service_cmd.py
@@ -1,0 +1,306 @@
+"""Always-on service commands: list, info, start, status, stop, run, logs."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+import typer
+from rich.table import Table
+
+from initrunner.cli._helpers import console
+
+app = typer.Typer(help="Start and operate curated always-on agent services.")
+
+
+def _parse_set_pairs(pairs: list[str] | None) -> dict[str, Any]:
+    """Parse ``key=value`` pairs; reject duplicates and malformed entries."""
+    out: dict[str, Any] = {}
+    for raw in pairs or []:
+        if "=" not in raw:
+            console.print(f"[red]Error:[/red] Expected key=value, got '{raw}'")
+            raise typer.Exit(1)
+        key, _, value = raw.partition("=")
+        key = key.strip()
+        if not key:
+            console.print(f"[red]Error:[/red] Empty key in '{raw}'")
+            raise typer.Exit(1)
+        if key in out:
+            console.print(f"[red]Error:[/red] Duplicate --set key '{key}'")
+            raise typer.Exit(1)
+        out[key] = value
+    return out
+
+
+@app.command("list")
+def service_list() -> None:
+    """List shipped services and local status."""
+    from initrunner.services.always_on import list_services
+
+    items = list_services()
+    if not items:
+        console.print("[dim]No services found in the catalog.[/dim]")
+        return
+
+    table = Table(title="Services")
+    table.add_column("Name", style="cyan")
+    table.add_column("Status")
+    table.add_column("Source")
+    table.add_column("Description")
+    for item in items:
+        status_style = {
+            "running": "green",
+            "stopped": "dim",
+        }.get(item.status.value, "")
+        status_label = f"[{status_style}]{item.status.value}[/{status_style}]"
+        table.add_row(
+            item.slug,
+            status_label,
+            item.source,
+            item.description or "—",
+        )
+    console.print(table)
+
+
+@app.command("info")
+def service_info(
+    slug: Annotated[str, typer.Argument(help="Service name")],
+) -> None:
+    """Show service metadata, params, and requirements."""
+    from initrunner.services.always_on import ServiceError, info_dict
+
+    try:
+        info = info_dict(slug)
+    except ServiceError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1) from None
+
+    console.print(f"[bold]{info['slug']}[/bold]  v{info['version'] or '?'}")
+    if info["description"]:
+        console.print(info["description"])
+    console.print(f"\n[dim]Source:[/dim] {info['source']}  [dim]Path:[/dim] {info['path']}")
+    console.print(f"[dim]Status:[/dim] {info['status']}")
+    console.print(f"[dim]Runtime agent name:[/dim] {info['runtime_agent_name']}")
+    if info.get("primary_param"):
+        console.print(f"[dim]Primary param:[/dim] {info['primary_param']}")
+    console.print(f"[dim]Default every:[/dim] {info['every']}")
+
+    if info["params"]:
+        console.print("\n[bold]Parameters[/bold]")
+        for name, p in info["params"].items():
+            req = "required" if p["required"] else "optional"
+            default = f", default={p['default']!r}" if p["default"] is not None else ""
+            vals = f", values={p['values']}" if p["values"] else ""
+            console.print(f"  [cyan]{name}[/cyan] ({p['type']}, {req}{default}{vals})")
+            if p["description"]:
+                console.print(f"    {p['description']}")
+
+    req = info["requires"]
+    if req["env"] or req["extras"]:
+        console.print("\n[bold]Requires[/bold]")
+        if req["env"]:
+            console.print(f"  env: {', '.join(req['env'])}")
+        if req["extras"]:
+            console.print(f"  extras: {', '.join(req['extras'])}")
+            # Escape [ ] so Rich does not treat extras as markup tags.
+            extras = ",".join(req["extras"])
+            console.print(f'  [dim]Install:[/dim] pip install "initrunner\\[{extras}]"')
+
+    defaults = info["defaults"]
+    console.print(
+        f"\n[dim]timezone:[/dim] {defaults['timezone']}  "
+        f"[dim]autonomy:[/dim] {defaults['autonomy']}"
+    )
+
+
+@app.command("start")
+def service_start(
+    slug: Annotated[str, typer.Argument(help="Service name")],
+    primary: Annotated[
+        str | None,
+        typer.Argument(help="Value for the service primary parameter (if any)"),
+    ] = None,
+    set_param: Annotated[
+        list[str] | None,
+        typer.Option("--set", help="Parameter as key=value (repeatable)"),
+    ] = None,
+    every: Annotated[
+        str | None,
+        typer.Option("--every", help="Schedule: hourly, daily, weekly, or 5-field cron"),
+    ] = None,
+    sink: Annotated[
+        list[str] | None,
+        typer.Option("--sink", help="Sink: file:/path or webhook:url (repeatable)"),
+    ] = None,
+) -> None:
+    """Start a service: materialize config and start its daemon."""
+    from initrunner.services.always_on import ServiceError, get_catalog_entry, start_service
+
+    try:
+        entry = get_catalog_entry(slug)
+    except ServiceError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1) from None
+
+    params = _parse_set_pairs(set_param)
+    primary_name = entry.definition.spec.primary_param
+    if primary is not None:
+        if not primary_name:
+            console.print(
+                f"[red]Error:[/red] Service '{slug}' has no primary parameter; use --set key=value."
+            )
+            raise typer.Exit(1)
+        if primary_name in params:
+            console.print(
+                f"[red]Error:[/red] Pass primary '{primary_name}' either as a "
+                f"positional argument or via --set, not both."
+            )
+            raise typer.Exit(1)
+        params[primary_name] = primary
+
+    try:
+        result = start_service(
+            slug,
+            params=params or None,
+            sinks=list(sink) if sink is not None else None,
+            every=every,
+        )
+    except ServiceError as e:
+        console.print("[red]Error:[/red]")
+        console.print(str(e), markup=False)
+        raise typer.Exit(1) from None
+
+    state = result.state
+    if result.idempotent:
+        console.print(f"[green]Already running[/green] {slug}")
+    else:
+        console.print(f"[green]Started[/green] {slug} ({state.status.value})")
+    if result.version_from and result.version_to and result.version_from != result.version_to:
+        console.print(f"  [dim]catalog version:[/dim] {result.version_from} → {result.version_to}")
+    if state.params:
+        console.print(f"  params: {state.params}")
+    console.print(f"  every: {state.every} ({state.resolved_cron} {state.timezone})")
+    if state.process:
+        console.print(f"  daemon pid: {state.process.pid}")
+    for path in state.output_paths:
+        console.print(f"  output: {path}")
+    console.print(
+        f"[dim]Status:[/dim] initrunner service status {slug}\n"
+        f"[dim]One-shot tick:[/dim] initrunner service run {slug}"
+    )
+
+
+@app.command("status")
+def service_status(
+    slug: Annotated[str, typer.Argument(help="Service name")],
+) -> None:
+    """Show start state, health, and recent activity."""
+    from initrunner.services.always_on import ProcessObservation, ServiceError, status
+
+    try:
+        view = status(slug)
+    except ServiceError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1) from None
+
+    s = view.state
+    console.print(f"[bold]{s.slug}[/bold]  status=[cyan]{s.status.value}[/cyan]")
+    if view.unverifiable_message:
+        console.print(f"  [yellow]warning:[/yellow] {view.unverifiable_message}")
+    if s.process and view.observation is ProcessObservation.VERIFIED_RUNNING:
+        console.print(f"  daemon: running  pid={s.process.pid}")
+    elif s.status.value == "running":
+        console.print(f"  daemon: {view.observation.value}")
+    else:
+        console.print("  daemon: stopped")
+    console.print(f"  every: {s.every} ({s.resolved_cron} {s.timezone})")
+    if s.params:
+        console.print(f"  params: {s.params}")
+    for path in s.output_paths:
+        console.print(f"  output: {path}")
+    if view.role_path:
+        console.print(f"  instance: {view.role_path}")
+    if view.last_run_at:
+        ok = "ok" if view.last_run_ok else "error"
+        console.print(f"  last run: {view.last_run_at}  {ok}")
+    else:
+        console.print("  last run: (never)")
+    if view.cost_today_usd is not None:
+        console.print(f"  cost today: ${view.cost_today_usd:.4f}")
+    if s.last_error:
+        console.print(f"  [yellow]last_error:[/yellow] {s.last_error}")
+    if view.log_tail and view.log_tail != "(no log yet)":
+        console.print("\n[dim]Log tail:[/dim]")
+        console.print(view.log_tail)
+
+
+@app.command("stop")
+def service_stop(
+    slug: Annotated[str, typer.Argument(help="Service name")],
+    purge: Annotated[
+        bool,
+        typer.Option(
+            "--purge",
+            help=(
+                "Delete instance config, logs, and file outputs under "
+                "~/.initrunner/services/<slug>. Does not delete audit history, "
+                "memory stores, or budget state."
+            ),
+        ),
+    ] = False,
+) -> None:
+    """Stop a service daemon; optionally purge local instance data."""
+    from initrunner.services.always_on import ServiceError, stop_service
+
+    try:
+        stop_service(slug, purge=purge)
+    except ServiceError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1) from None
+    if purge:
+        console.print(f"[green]Stopped and purged[/green] {slug}")
+    else:
+        console.print(f"[green]Stopped[/green] {slug} (instance retained)")
+
+
+@app.command("logs")
+def service_logs_cmd(
+    slug: Annotated[str, typer.Argument(help="Service name")],
+    lines: Annotated[int, typer.Option("--lines", "-n", help="Lines to show")] = 50,
+) -> None:
+    """Show recent daemon log lines for a service."""
+    from initrunner.services.always_on import ServiceError, service_logs
+
+    try:
+        text = service_logs(slug, lines=lines)
+    except ServiceError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1) from None
+    console.print(text)
+
+
+@app.command("run")
+def service_run(
+    slug: Annotated[str, typer.Argument(help="Service name")],
+    model: Annotated[
+        str | None,
+        typer.Option("--model", help="Model override (provider:name)"),
+    ] = None,
+) -> None:
+    """Force one service tick now (stops the daemon briefly if it was running)."""
+    from initrunner.services.always_on import ServiceError, forced_run
+
+    try:
+        result = forced_run(slug, model=model)
+    except ServiceError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1) from None
+
+    if result.was_running:
+        console.print(f"[dim]Stopped daemon for one-shot tick on {slug}…[/dim]")
+    else:
+        console.print(f"[dim]Running one-shot tick for {slug}…[/dim]")
+    for msg in result.messages:
+        console.print(f"[yellow]{msg}[/yellow]", markup=False)
+    if result.exit_code != 0:
+        raise typer.Exit(result.exit_code)
+    console.print(f"[green]Tick complete[/green] for {slug}")

--- a/initrunner/config.py
+++ b/initrunner/config.py
@@ -83,3 +83,8 @@ def get_vault_path() -> Path:
 
 def get_telemetry_config_path() -> Path:
     return get_home_dir() / "telemetry.json"
+
+
+def get_services_dir() -> Path:
+    """Runtime state for always-on services (``~/.initrunner/services``)."""
+    return get_home_dir() / "services"

--- a/initrunner/service_catalog/__init__.py
+++ b/initrunner/service_catalog/__init__.py
@@ -1,0 +1,12 @@
+"""Shipped always-on service catalog (collector, …)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+CATALOG_ROOT = Path(__file__).resolve().parent
+
+
+def catalog_root() -> Path:
+    """Return the directory that contains shipped service templates."""
+    return CATALOG_ROOT

--- a/initrunner/service_catalog/collector/role.yaml
+++ b/initrunner/service_catalog/collector/role.yaml
@@ -1,0 +1,60 @@
+apiVersion: initrunner/v1
+kind: Agent
+metadata:
+  name: collector
+  description: Continuous OSINT-style monitor for a single target
+  tags: [service, monitor, always-on]
+spec:
+  role: |
+    You are Collector, an always-on intelligence agent for InitRunner services.
+
+    ## Target
+    Primary target: **{{ params.target }}**
+    Alert severity threshold: **{{ params.alert_severity }}**
+
+    ## Mission
+    On each scheduled run you:
+    1. **Recall** — Use recall() for prior facts, prior summaries, and open questions about the target.
+    2. **Gather** — Search the web and fetch a few high-signal pages (news, company site, filings, social mentions as available). Prefer primary sources.
+    3. **Diff** — Compare new findings to memory. Ignore noise. Focus on material changes: leadership, product, funding, incidents, legal, major messaging shifts.
+    4. **Score** — Rate significance low / medium / high. Only treat findings at or above the configured severity as alerts.
+    5. **Remember** — Store durable facts with remember() (entities, dates, claims with sources). Use record_episode() for what you did this run.
+    6. **Report** — Produce a concise markdown briefing:
+       - Header with target + UTC time
+       - What changed (or "No material change")
+       - Evidence with URLs
+       - Open questions for next run
+
+    ## Rules
+    - Do not invent facts. If uncertain, say so.
+    - Cap tool use: a handful of searches and page reads, not an infinite crawl.
+    - Keep the report under ~800 words unless there is a high-severity incident.
+    - Never exfiltrate secrets; only use public information.
+  tools:
+    - type: search
+      max_results: 8
+    - type: web_reader
+      max_length: 12000
+    - type: datetime
+  memory:
+    max_sessions: 20
+    max_resume_messages: 30
+    semantic:
+      max_memories: 2000
+    episodic:
+      max_episodes: 500
+    consolidation:
+      enabled: true
+      interval: after_session
+  triggers:
+    - type: cron
+      schedule: "0 6 * * *"
+      prompt: "Run the collector cycle for the configured target."
+      timezone: UTC
+  guardrails:
+    max_tokens_per_run: 40000
+    max_tool_calls: 25
+    timeout_seconds: 180
+    daemon_daily_token_budget: 200000
+  security:
+    preset: internal

--- a/initrunner/service_catalog/collector/service.yaml
+++ b/initrunner/service_catalog/collector/service.yaml
@@ -1,0 +1,45 @@
+apiVersion: initrunner/v1
+kind: Service
+metadata:
+  name: collector
+  version: "1.0.0"
+  description: Continuous monitoring for a target — change detection and alerts
+  tags: [monitor, research, always-on]
+  author: InitRunner Team
+spec:
+  entry:
+    kind: Agent
+    path: role.yaml
+  primary_param: target
+  every: daily
+  params:
+    target:
+      type: string
+      required: true
+      description: Company, person, domain, or topic to monitor
+    alert_severity:
+      type: enum
+      values: [low, medium, high]
+      default: medium
+      description: Minimum significance before alerting
+  defaults:
+    autonomy: false
+    sinks:
+      - type: file
+        path: collector-report.md
+        format: text
+    guardrails:
+      max_tokens_per_run: 40000
+      max_tool_calls: 25
+      timeout_seconds: 180
+      daemon_daily_token_budget: 200000
+    timezone: UTC
+  requires:
+    env: []
+    extras: [search]
+  schedule_prompt: >
+    Monitor target "{{ params.target }}". Gather fresh public signals,
+    compare with what you remember, score significance against alert
+    severity "{{ params.alert_severity }}", remember durable facts, and
+    write a brief only if something meaningful changed (or a short
+    all-clear summary otherwise).

--- a/initrunner/services/always_on.py
+++ b/initrunner/services/always_on.py
@@ -1,0 +1,1348 @@
+"""Always-on service lifecycle: catalog, start, stop, status, run.
+
+Services are declarative bundles (service.yaml + role) with operate-time state
+under ``~/.initrunner/services/<slug>/``. Runtime v1 uses one daemon process
+per running service via ``python -m initrunner run <instance> --daemon``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import ValidationError
+
+from initrunner._paths import ensure_private_dir
+from initrunner.agent.schema.service import (
+    SERVICE_NAME_RE,
+    ProcessIdentity,
+    ServiceDefinition,
+    ServiceParam,
+    ServiceParamType,
+    ServiceState,
+    ServiceStatus,
+)
+from initrunner.config import get_services_dir
+from initrunner.service_catalog import catalog_root
+
+_logger = logging.getLogger(__name__)
+
+_PARAM_RE = re.compile(r"\{\{\s*params\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
+_STATE_FILE = "state.json"
+_LOG_FILE = "daemon.log"
+_LOCK_TIMEOUT_S = 30.0
+_CRON_PRESETS = {
+    "hourly": "0 * * * *",
+    "daily": "0 6 * * *",
+    "weekly": "0 8 * * 1",
+}
+_CRON_RE = re.compile(r"^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)$")
+
+# Injectable for tests: (role_path, log_path, cwd, env) -> pid
+DaemonLauncher = Any
+
+
+class ServiceError(Exception):
+    """User-facing service lifecycle error."""
+
+
+class ProcessObservation(StrEnum):
+    VERIFIED_RUNNING = "verified_running"
+    VERIFIED_DEAD = "verified_dead"
+    UNVERIFIABLE = "unverifiable"
+
+
+# ---------------------------------------------------------------------------
+# Platform
+# ---------------------------------------------------------------------------
+
+
+def require_linux_supervision() -> None:
+    if sys.platform != "linux":
+        raise ServiceError(
+            "Always-on service start/stop/run requires Linux in v1 "
+            f"(this platform is {sys.platform!r})."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Slug + paths
+# ---------------------------------------------------------------------------
+
+
+def validate_slug(slug: str) -> str:
+    if not isinstance(slug, str) or not SERVICE_NAME_RE.fullmatch(slug):
+        raise ServiceError(
+            f"Invalid service name {slug!r}. "
+            "Use lowercase letters, digits, and hyphens "
+            "(e.g. collector)."
+        )
+    return slug
+
+
+def _services_root() -> Path:
+    return get_services_dir().resolve()
+
+
+def instance_dir(slug: str) -> Path:
+    """Return instance directory; rejects path traversal."""
+    slug = validate_slug(slug)
+    root = _services_root()
+    ensure_private_dir(root)
+    candidate = (root / slug).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as e:
+        raise ServiceError(f"Invalid service path for {slug!r}") from e
+    if candidate == root:
+        raise ServiceError(f"Invalid service path for {slug!r}")
+    return candidate
+
+
+def locks_dir() -> Path:
+    root = _services_root()
+    ensure_private_dir(root)
+    d = root / ".locks"
+    ensure_private_dir(d)
+    return d
+
+
+def lock_path(slug: str) -> Path:
+    slug = validate_slug(slug)
+    return locks_dir() / f"{slug}.lock"
+
+
+def runtime_agent_name(slug: str) -> str:
+    return f"service-{validate_slug(slug)}"
+
+
+def _atomic_write_text(path: Path, text: str, *, mode: int = 0o600) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    try:
+        tmp.write_text(text, encoding="utf-8")
+        if sys.platform != "win32":
+            try:
+                tmp.chmod(mode)
+            except OSError:
+                pass
+        os.replace(tmp, path)
+    finally:
+        if tmp.exists():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+
+@contextmanager
+def service_lock(slug: str, *, timeout: float = _LOCK_TIMEOUT_S) -> Iterator[None]:
+    """Exclusive lifecycle lock (fcntl); lock files live outside instance dirs."""
+    require_linux_supervision()
+    import fcntl
+
+    path = lock_path(slug)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Open without truncating so concurrent waiters share the inode name.
+    fd = os.open(str(path), os.O_RDWR | os.O_CREAT, 0o600)
+    deadline = time.monotonic() + timeout
+    try:
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if time.monotonic() >= deadline:
+                    raise ServiceError(
+                        f"Another operation is running on service '{slug}'. Retry in a moment."
+                    ) from None
+                time.sleep(0.05)
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        os.close(fd)
+
+
+# ---------------------------------------------------------------------------
+# Catalog
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CatalogEntry:
+    slug: str
+    path: Path
+    definition: ServiceDefinition
+    source: str  # "shipped" | "extra"
+
+
+@dataclass
+class ServiceListItem:
+    slug: str
+    description: str
+    version: str
+    source: str
+    status: ServiceStatus
+    params: dict[str, Any] = field(default_factory=dict)
+
+
+def _load_service_yaml(path: Path) -> ServiceDefinition:
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except OSError as e:
+        raise ServiceError(f"Cannot read {path}: {e}") from e
+    if not isinstance(raw, dict):
+        raise ServiceError(f"Invalid service manifest (not a mapping): {path}")
+    try:
+        return ServiceDefinition.model_validate(raw)
+    except ValidationError as e:
+        raise ServiceError(f"Invalid service manifest {path}: {e}") from e
+
+
+def discover_catalog(*, extra_dirs: list[Path] | None = None) -> list[CatalogEntry]:
+    """Scan shipped catalog (and optional test-only extra dirs)."""
+    roots: list[tuple[Path, str]] = [(catalog_root(), "shipped")]
+    for d in extra_dirs or []:
+        if d.is_dir():
+            roots.append((d.resolve(), "extra"))
+
+    by_slug: dict[str, CatalogEntry] = {}
+    for root, source in roots:
+        if not root.is_dir():
+            continue
+        for child in sorted(root.iterdir()):
+            if not child.is_dir() or child.name.startswith(("_", ".")):
+                continue
+            manifest = child / "service.yaml"
+            if not manifest.is_file():
+                continue
+            try:
+                definition = _load_service_yaml(manifest)
+            except ServiceError as e:
+                _logger.warning("Skipping service at %s: %s", child, e)
+                continue
+            slug = definition.metadata.name
+            by_slug[slug] = CatalogEntry(
+                slug=slug, path=child, definition=definition, source=source
+            )
+    return sorted(by_slug.values(), key=lambda e: e.slug)
+
+
+def get_catalog_entry(slug: str, *, extra_dirs: list[Path] | None = None) -> CatalogEntry:
+    slug = validate_slug(slug)
+    for entry in discover_catalog(extra_dirs=extra_dirs):
+        if entry.slug == slug:
+            return entry
+    raise ServiceError(
+        f"Unknown service '{slug}'. Run `initrunner service list` to see available services."
+    )
+
+
+# ---------------------------------------------------------------------------
+# State
+# ---------------------------------------------------------------------------
+
+
+def _state_path(slug: str) -> Path:
+    return instance_dir(slug) / _STATE_FILE
+
+
+def load_state(slug: str) -> ServiceState | None:
+    path = _state_path(slug)
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return ServiceState.model_validate(data)
+    except (OSError, json.JSONDecodeError, ValidationError) as e:
+        raise ServiceError(f"Corrupt service state for '{slug}': {e}") from e
+
+
+def save_state(state: ServiceState) -> None:
+    d = instance_dir(state.slug)
+    ensure_private_dir(d)
+    ensure_private_dir(d / "data")
+    _atomic_write_text(
+        _state_path(state.slug),
+        state.model_dump_json(indent=2) + "\n",
+    )
+
+
+def role_path_for_state(state: ServiceState) -> Path:
+    if not state.role_file:
+        raise ServiceError(f"Service '{state.slug}' has no materialized role")
+    path = instance_dir(state.slug) / state.role_file
+    # Containment
+    root = instance_dir(state.slug).resolve()
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as e:
+        raise ServiceError("Invalid role path in state") from e
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# Params + cadence
+# ---------------------------------------------------------------------------
+
+
+def resolve_params(
+    definition: ServiceDefinition,
+    provided: dict[str, Any],
+) -> dict[str, Any]:
+    resolved: dict[str, Any] = {}
+    unknown = set(provided) - set(definition.spec.params)
+    if unknown:
+        raise ServiceError(
+            f"Unknown parameter(s): {', '.join(sorted(unknown))}. "
+            f"Valid: {', '.join(sorted(definition.spec.params)) or '(none)'}"
+        )
+    for name, spec in definition.spec.params.items():
+        if name in provided:
+            value = provided[name]
+        elif spec.default is not None:
+            value = spec.default
+        elif spec.required:
+            raise ServiceError(
+                f"Missing required parameter '{name}'. "
+                f"{spec.description or 'See `initrunner service info`.'}"
+            )
+        else:
+            continue
+        resolved[name] = _coerce_param(name, value, spec)
+    return resolved
+
+
+def _coerce_param(name: str, value: Any, spec: ServiceParam) -> Any:
+    if spec.type == ServiceParamType.STRING:
+        return str(value)
+    if spec.type == ServiceParamType.INT:
+        try:
+            return int(value)
+        except (TypeError, ValueError) as e:
+            raise ServiceError(f"Parameter '{name}' must be an integer") from e
+    if spec.type == ServiceParamType.BOOL:
+        if isinstance(value, bool):
+            return value
+        s = str(value).lower()
+        if s in ("true", "1", "yes", "on"):
+            return True
+        if s in ("false", "0", "no", "off"):
+            return False
+        raise ServiceError(f"Parameter '{name}' must be a boolean")
+    if spec.type == ServiceParamType.ENUM:
+        s = str(value)
+        if s not in spec.values:
+            raise ServiceError(f"Parameter '{name}' must be one of: {', '.join(spec.values)}")
+        return s
+    return value
+
+
+def resolve_every(every: str) -> str:
+    """Return validated cron expression from preset or raw cron."""
+    raw = every.strip()
+    if not raw:
+        raise ServiceError("Schedule (--every) must not be empty")
+    key = raw.lower()
+    if key in _CRON_PRESETS:
+        return _CRON_PRESETS[key]
+    if not _CRON_RE.match(raw):
+        raise ServiceError(
+            f"Invalid schedule {every!r}. Use hourly, daily, weekly, or a 5-field cron expression."
+        )
+    # Basic rejection of empties already handled; accept 5 fields.
+    return raw
+
+
+def parse_sink_specs(sink_args: list[str]) -> list[dict[str, Any]]:
+    sinks: list[dict[str, Any]] = []
+    for raw in sink_args:
+        if raw.startswith("file:"):
+            rest = raw[5:]
+            if rest.endswith(":json"):
+                path, fmt = rest[:-5], "json"
+            elif rest.endswith(":text"):
+                path, fmt = rest[:-5], "text"
+            else:
+                path, fmt = rest, "text" if rest.endswith((".md", ".txt")) else "json"
+            if not path:
+                raise ServiceError(f"Invalid file sink: {raw}")
+            sinks.append({"type": "file", "path": path, "format": fmt})
+        elif raw.startswith("webhook:"):
+            url = raw[len("webhook:") :]
+            if not url:
+                raise ServiceError(f"Invalid webhook sink: {raw}")
+            sinks.append({"type": "webhook", "url": url})
+        else:
+            raise ServiceError(
+                f"Unknown sink format '{raw}'. Use file:/path or webhook:https://..."
+            )
+    return sinks
+
+
+def _substitute_params(text: str, params: dict[str, Any]) -> str:
+    def repl(match: re.Match[str]) -> str:
+        key = match.group(1)
+        if key not in params:
+            raise ServiceError(f"Template references params.{key} but that parameter was not set")
+        return str(params[key])
+
+    return _PARAM_RE.sub(repl, text)
+
+
+def _resolve_file_sink_path(path_str: str, data_dir: Path) -> str:
+    p = Path(path_str)
+    if p.is_absolute():
+        return str(p)
+    # Relative: must stay under data_dir
+    data_dir = data_dir.resolve()
+    # Reject path parts that escape
+    if ".." in p.parts:
+        raise ServiceError(f"Relative sink path must not contain '..': {path_str}")
+    resolved = (data_dir / p).resolve()
+    try:
+        resolved.relative_to(data_dir)
+    except ValueError as e:
+        raise ServiceError(f"Sink path escapes service data directory: {path_str}") from e
+    return str(resolved)
+
+
+def materialize_instance_role(
+    entry: CatalogEntry,
+    params: dict[str, Any],
+    sinks: list[dict[str, Any]] | None,
+    *,
+    every: str,
+    resolved_cron: str,
+    timezone: str,
+    dest: Path,
+) -> tuple[str, list[dict[str, Any]]]:
+    """Render role to dest; return (sha256 digest, resolved sink configs)."""
+    del every  # schedule is carried only via resolved_cron
+    definition = entry.definition
+    if definition.spec.entry.kind != "Agent":
+        raise ServiceError("Only Agent entry services are supported in v1")
+
+    role_src = entry.path / definition.spec.entry.path
+    if not role_src.is_file():
+        raise ServiceError(f"Service entry role not found: {role_src}")
+
+    template = role_src.read_text(encoding="utf-8")
+    rendered = _substitute_params(template, params)
+
+    try:
+        data = yaml.safe_load(rendered)
+    except yaml.YAMLError as e:
+        raise ServiceError(f"Rendered role YAML is invalid: {e}") from e
+    if not isinstance(data, dict):
+        raise ServiceError("Rendered role YAML must be a mapping")
+
+    # Force runtime agent name for audit/memory/budget isolation
+    meta = data.setdefault("metadata", {})
+    if not isinstance(meta, dict):
+        raise ServiceError("Rendered role metadata must be a mapping")
+    meta["name"] = runtime_agent_name(entry.slug)
+
+    spec = data.setdefault("spec", {})
+    if not isinstance(spec, dict):
+        raise ServiceError("Rendered role spec must be a mapping")
+
+    prompt = _substitute_params(definition.spec.schedule_prompt, params)
+    spec["triggers"] = [
+        {
+            "type": "cron",
+            "schedule": resolved_cron,
+            "prompt": prompt,
+            "timezone": timezone,
+            "autonomous": definition.spec.defaults.autonomy,
+        }
+    ]
+
+    data_dir = dest.parent / "data"
+    ensure_private_dir(data_dir)
+    final_sinks: list[dict[str, Any]] = (
+        list(definition.spec.defaults.sinks) if sinks is None else list(sinks)
+    )
+    resolved_sinks: list[dict[str, Any]] = []
+    for s in final_sinks:
+        s = dict(s)
+        if s.get("type") == "file" and "path" in s:
+            s["path"] = _resolve_file_sink_path(str(s["path"]), data_dir)
+        resolved_sinks.append(s)
+    if resolved_sinks:
+        spec["sinks"] = resolved_sinks
+    else:
+        spec.pop("sinks", None)
+
+    if definition.spec.defaults.guardrails:
+        existing = spec.get("guardrails") or {}
+        if not isinstance(existing, dict):
+            existing = {}
+        spec["guardrails"] = {**definition.spec.defaults.guardrails, **existing}
+
+    if definition.spec.defaults.autonomy and not spec.get("autonomy"):
+        spec["autonomy"] = {}
+
+    text = yaml.safe_dump(data, sort_keys=False, default_flow_style=False)
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    _atomic_write_text(dest, text)
+    return digest, resolved_sinks
+
+
+# ---------------------------------------------------------------------------
+# Requires
+# ---------------------------------------------------------------------------
+
+
+def check_requires(definition: ServiceDefinition) -> list[str]:
+    missing: list[str] = []
+    for var in definition.spec.requires.env:
+        if not os.environ.get(var):
+            missing.append(f"env:{var}")
+    for extra in definition.spec.requires.extras:
+        if not _extra_available(extra):
+            missing.append(f'extra:{extra} (pip install "initrunner[{extra}]")')
+    return missing
+
+
+def _extra_available(extra: str) -> bool:
+    markers = {
+        "search": "ddgs",
+        "ingest": "pymupdf4llm",
+        "telegram": "telegram",
+        "discord": "discord",
+        "slack": "slack_sdk",
+        "audio": "youtube_transcript_api",
+        "dashboard": "fastapi",
+    }
+    mod = markers.get(extra)
+    if mod is None:
+        return True
+    try:
+        __import__(mod)
+        return True
+    except ImportError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Process identity (Linux)
+# ---------------------------------------------------------------------------
+
+
+def _read_boot_id() -> str | None:
+    try:
+        return Path("/proc/sys/kernel/random/boot_id").read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+
+
+def _read_proc_start_ticks(pid: int) -> int | None:
+    try:
+        # /proc/<pid>/stat: starttime is field 22 (1-based), after comm in parens
+        raw = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+    except OSError:
+        return None
+    # comm can contain spaces/parens — split after last ')'
+    rparen = raw.rfind(")")
+    if rparen < 0:
+        return None
+    fields = raw[rparen + 2 :].split()
+    # fields[0] is state (field 3), starttime is field 22 → index 19 in post-comm
+    try:
+        return int(fields[19])
+    except (IndexError, ValueError):
+        return None
+
+
+def _cmdline_contains_role(pid: int, role_path: str) -> bool:
+    try:
+        data = Path(f"/proc/{pid}/cmdline").read_bytes()
+    except OSError:
+        return False
+    parts = [p.decode("utf-8", errors="replace") for p in data.split(b"\0") if p]
+    role = str(Path(role_path).resolve())
+    return any(role in p or p == role for p in parts)
+
+
+def _reap_if_child(pid: int) -> None:
+    """Reap pid if it is our child (avoids zombies looking 'alive' to kill(0))."""
+    try:
+        os.waitpid(pid, os.WNOHANG)
+    except ChildProcessError:
+        pass
+    except OSError:
+        pass
+
+
+def _pid_zombie(pid: int) -> bool:
+    if sys.platform != "linux":
+        return False
+    try:
+        raw = Path(f"/proc/{pid}/stat").read_text(encoding="utf-8")
+    except OSError:
+        return False
+    rparen = raw.rfind(")")
+    if rparen < 0:
+        return False
+    # State char is the next field after ``) ``
+    try:
+        return raw[rparen + 2] == "Z"
+    except IndexError:
+        return False
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    if _pid_zombie(pid):
+        _reap_if_child(pid)
+        return False
+    return True
+
+
+def collect_process_identity(pid: int, role_path: str) -> ProcessIdentity | None:
+    if sys.platform != "linux":
+        return None
+    if not _pid_alive(pid):
+        return None
+    boot = _read_boot_id()
+    ticks = _read_proc_start_ticks(pid)
+    if boot is None or ticks is None:
+        return None
+    if not _cmdline_contains_role(pid, role_path):
+        return None
+    return ProcessIdentity(
+        pid=pid,
+        boot_id=boot,
+        proc_start_ticks=ticks,
+        role_path=str(Path(role_path).resolve()),
+        started_at=datetime.now(UTC).isoformat(),
+    )
+
+
+def observe_process(identity: ProcessIdentity | None) -> ProcessObservation:
+    if identity is None:
+        return ProcessObservation.VERIFIED_DEAD
+    if sys.platform != "linux":
+        if _pid_alive(identity.pid):
+            return ProcessObservation.UNVERIFIABLE
+        return ProcessObservation.VERIFIED_DEAD
+
+    if not _pid_alive(identity.pid):
+        return ProcessObservation.VERIFIED_DEAD
+
+    boot = _read_boot_id()
+    ticks = _read_proc_start_ticks(identity.pid)
+    if boot is None or ticks is None:
+        return ProcessObservation.UNVERIFIABLE
+    if boot != identity.boot_id or ticks != identity.proc_start_ticks:
+        return ProcessObservation.VERIFIED_DEAD
+    if not _cmdline_contains_role(identity.pid, identity.role_path):
+        return ProcessObservation.VERIFIED_DEAD
+    return ProcessObservation.VERIFIED_RUNNING
+
+
+# ---------------------------------------------------------------------------
+# Daemon supervision
+# ---------------------------------------------------------------------------
+
+
+def _log_path(slug: str) -> Path:
+    return instance_dir(slug) / _LOG_FILE
+
+
+def _tail_log(slug: str, *, lines: int = 50) -> str:
+    path = _log_path(slug)
+    if not path.is_file():
+        return "(no log yet)"
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        return f"(cannot read log: {e})"
+    parts = content.splitlines()
+    return "\n".join(parts[-lines:]) if parts else "(empty log)"
+
+
+def _default_daemon_launcher(
+    role_path: Path, log_path: Path, cwd: Path, env: dict[str, str]
+) -> int:
+    cmd = [
+        sys.executable,
+        "-m",
+        "initrunner",
+        "run",
+        str(role_path.resolve()),
+        "--daemon",
+    ]
+    with open(log_path, "ab") as log_f:
+        log_f.write(f"\n--- start {datetime.now(UTC).isoformat()} ---\n".encode())
+        log_f.flush()
+        proc = subprocess.Popen(
+            cmd,
+            stdout=log_f,
+            stderr=subprocess.STDOUT,
+            cwd=str(cwd),
+            env=env,
+            start_new_session=True,
+        )
+    return proc.pid
+
+
+_daemon_launcher: DaemonLauncher = _default_daemon_launcher
+
+
+def set_daemon_launcher(launcher: DaemonLauncher | None) -> None:
+    """Test hook: replace or restore the daemon process launcher."""
+    global _daemon_launcher
+    _daemon_launcher = launcher or _default_daemon_launcher
+
+
+def start_daemon(slug: str, role_path: Path) -> ProcessIdentity:
+    """Spawn supervised child; return identity. Does not update state."""
+    require_linux_supervision()
+    ensure_private_dir(instance_dir(slug))
+    log_path = _log_path(slug)
+    env = os.environ.copy()
+    env.setdefault("INITRUNNER_NO_TELEMETRY_PROMPT", "1")
+
+    pid = _daemon_launcher(role_path, log_path, instance_dir(slug), env)
+    time.sleep(0.3)
+    if not _pid_alive(pid):
+        tail = _tail_log(slug, lines=20)
+        raise ServiceError(f"Service daemon for '{slug}' exited immediately.\nLog tail:\n{tail}")
+    identity = collect_process_identity(pid, str(role_path))
+    if identity is None:
+        # Child alive but we cannot prove identity — fail closed: try to stop it
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except OSError:
+            pass
+        raise ServiceError(
+            f"Could not verify process identity for service '{slug}' "
+            f"(pid {pid}). Not marking as running."
+        )
+    return identity
+
+
+def stop_daemon_identity(identity: ProcessIdentity, *, timeout: float = 5.0) -> None:
+    """Signal only if still verified_running for this identity."""
+    obs = observe_process(identity)
+    if obs is ProcessObservation.VERIFIED_DEAD:
+        _reap_if_child(identity.pid)
+        return
+    if obs is ProcessObservation.UNVERIFIABLE:
+        raise ServiceError(
+            f"Process pid={identity.pid} is alive but identity cannot be verified. "
+            "Refusing to signal it. Inspect the process manually."
+        )
+    try:
+        os.kill(identity.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        _reap_if_child(identity.pid)
+        return
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        _reap_if_child(identity.pid)
+        if observe_process(identity) is ProcessObservation.VERIFIED_DEAD:
+            return
+        time.sleep(0.05)
+    # Last resort only if still verified
+    if observe_process(identity) is not ProcessObservation.VERIFIED_RUNNING:
+        _reap_if_child(identity.pid)
+        return
+    try:
+        os.kill(identity.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        _reap_if_child(identity.pid)
+        return
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline:
+        _reap_if_child(identity.pid)
+        if observe_process(identity) is ProcessObservation.VERIFIED_DEAD:
+            return
+        time.sleep(0.05)
+    _reap_if_child(identity.pid)
+
+
+def _gc_old_roles(slug: str, keep_generation: int, *, keep: int = 2) -> None:
+    d = instance_dir(slug)
+    if not d.is_dir():
+        return
+    gens: list[tuple[int, Path]] = []
+    for p in d.glob("role.*.yaml"):
+        try:
+            n = int(p.name.removeprefix("role.").removesuffix(".yaml"))
+        except ValueError:
+            continue
+        gens.append((n, p))
+    gens.sort(key=lambda x: x[0], reverse=True)
+    to_keep = {keep_generation}
+    for n, _ in gens:
+        if len(to_keep) >= keep:
+            break
+        to_keep.add(n)
+    for n, p in gens:
+        if n not in to_keep:
+            try:
+                p.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def _output_paths_from_sinks(sinks: list[dict[str, Any]]) -> list[str]:
+    out: list[str] = []
+    for s in sinks:
+        if s.get("type") == "file" and s.get("path"):
+            out.append(str(s["path"]))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def list_services(*, extra_dirs: list[Path] | None = None) -> list[ServiceListItem]:
+    items: list[ServiceListItem] = []
+    for entry in discover_catalog(extra_dirs=extra_dirs):
+        state = load_state(entry.slug)
+        status = ServiceStatus.STOPPED
+        params: dict[str, Any] = {}
+        if state is not None:
+            state = _heal_state(state)
+            status = state.status
+            params = state.params
+        items.append(
+            ServiceListItem(
+                slug=entry.slug,
+                description=entry.definition.metadata.description,
+                version=entry.definition.metadata.version or "",
+                source=entry.source,
+                status=status,
+                params=params,
+            )
+        )
+    # Orphan instances (catalog removed)
+    root = get_services_dir()
+    if root.is_dir():
+        known = {i.slug for i in items}
+        for child in sorted(root.iterdir()):
+            if not child.is_dir() or child.name.startswith(".") or child.name in known:
+                continue
+            try:
+                validate_slug(child.name)
+            except ServiceError:
+                continue
+            state = load_state(child.name)
+            if state is None:
+                continue
+            state = _heal_state(state)
+            items.append(
+                ServiceListItem(
+                    slug=state.slug,
+                    description="(catalog entry missing)",
+                    version=state.service_version,
+                    source="orphan",
+                    status=state.status,
+                    params=state.params,
+                )
+            )
+    return items
+
+
+def _heal_state(state: ServiceState) -> ServiceState:
+    if state.status != ServiceStatus.RUNNING:
+        return state
+    obs = observe_process(state.process)
+    if obs is ProcessObservation.VERIFIED_RUNNING:
+        return state
+    if obs is ProcessObservation.UNVERIFIABLE:
+        # Do not rewrite state
+        return state
+    # verified_dead
+    state.status = ServiceStatus.STOPPED
+    state.process = None
+    state.last_error = "daemon process not found or identity mismatch (stopped externally?)"
+    state.stopped_at = datetime.now(UTC).isoformat()
+    save_state(state)
+    return state
+
+
+@dataclass
+class StartResult:
+    state: ServiceState
+    version_from: str = ""
+    version_to: str = ""
+    idempotent: bool = False
+
+
+def start_service(
+    slug: str,
+    *,
+    params: dict[str, Any] | None = None,
+    sinks: list[str] | None = None,
+    every: str | None = None,
+    extra_dirs: list[Path] | None = None,
+    has_overrides: bool | None = None,
+) -> StartResult:
+    """Start a service: materialize if needed, start daemon under lock."""
+    slug = validate_slug(slug)
+    with service_lock(slug):
+        return _start_service_unlocked(
+            slug,
+            params=params,
+            sinks=sinks,
+            every=every,
+            extra_dirs=extra_dirs,
+            has_overrides=has_overrides,
+        )
+
+
+def _start_service_unlocked(
+    slug: str,
+    *,
+    params: dict[str, Any] | None = None,
+    sinks: list[str] | None = None,
+    every: str | None = None,
+    extra_dirs: list[Path] | None = None,
+    has_overrides: bool | None = None,
+) -> StartResult:
+    require_linux_supervision()
+    entry = get_catalog_entry(slug, extra_dirs=extra_dirs)
+    definition = entry.definition
+
+    missing = check_requires(definition)
+    if missing:
+        raise ServiceError(
+            "Missing requirements:\n  - "
+            + "\n  - ".join(missing)
+            + "\nFix these, then re-run start."
+        )
+
+    provided = dict(params or {})
+    sink_args = list(sinks) if sinks is not None else None
+    if has_overrides is None:
+        has_overrides = bool(provided) or sink_args is not None or every is not None
+
+    existing = load_state(slug)
+    if existing is not None:
+        existing = _heal_state(existing)
+
+    if existing and existing.status == ServiceStatus.RUNNING:
+        obs = observe_process(existing.process)
+        if obs is ProcessObservation.UNVERIFIABLE:
+            raise ServiceError(
+                f"Service '{slug}' has an unverifiable running process "
+                f"(pid={existing.process.pid if existing.process else '?'}). "
+                "Resolve manually before starting again."
+            )
+        if obs is ProcessObservation.VERIFIED_RUNNING:
+            if has_overrides:
+                raise ServiceError(
+                    f"Service '{slug}' is already running. Stop it before changing configuration."
+                )
+            return StartResult(state=existing, idempotent=True)
+        # verified_dead healed above
+
+    # Resolve config
+    if existing and not has_overrides:
+        role = role_path_for_state(existing)
+        if not role.is_file():
+            raise ServiceError(f"Instance role missing for '{slug}'. Start with parameters again.")
+        identity = start_daemon(slug, role)
+        existing.status = ServiceStatus.RUNNING
+        existing.process = identity
+        existing.stopped_at = None
+        existing.last_error = None
+        if existing.started_at is None:
+            existing.started_at = datetime.now(UTC).isoformat()
+        save_state(existing)
+        return StartResult(state=existing)
+
+    # Materialize (first start or overrides)
+    base_params = dict(existing.params) if existing else {}
+    base_params.update(provided)
+    resolved = resolve_params(definition, base_params)
+
+    if every is not None:
+        every_val = every
+    elif existing is not None:
+        every_val = existing.every
+    else:
+        every_val = definition.spec.every
+    cron = resolve_every(every_val)
+    timezone = definition.spec.defaults.timezone
+
+    # None → catalog defaults inside materialize; list → replace (possibly empty)
+    if sink_args is not None:
+        mat_sink_arg: list[dict[str, Any]] | None = parse_sink_specs(sink_args)
+    elif existing is not None and existing.sinks:
+        mat_sink_arg = list(existing.sinks)
+    else:
+        mat_sink_arg = None
+
+    d = instance_dir(slug)
+    ensure_private_dir(d)
+    ensure_private_dir(d / "data")
+    generation = (existing.generation if existing else 0) + 1
+    role_file = f"role.{generation}.yaml"
+    dest = d / role_file
+
+    digest, mat_sinks = materialize_instance_role(
+        entry,
+        resolved,
+        mat_sink_arg,
+        every=every_val,
+        resolved_cron=cron,
+        timezone=timezone,
+        dest=dest,
+    )
+
+    now = datetime.now(UTC).isoformat()
+    prev_version = existing.service_version if existing else ""
+    new_version = definition.metadata.version or ""
+
+    state = ServiceState(
+        slug=slug,
+        service_version=new_version,
+        status=ServiceStatus.STOPPED,
+        params=resolved,
+        sinks=mat_sinks,
+        every=every_val,
+        resolved_cron=cron,
+        timezone=timezone,
+        started_at=existing.started_at if existing else None,
+        stopped_at=now,
+        generation=generation,
+        role_file=role_file,
+        role_digest=digest,
+        catalog_path=str(entry.path),
+        process=None,
+        last_error=None,
+        output_paths=_output_paths_from_sinks(mat_sinks),
+    )
+    save_state(state)
+    _gc_old_roles(slug, generation)
+
+    identity = start_daemon(slug, dest)
+
+    state.status = ServiceStatus.RUNNING
+    state.process = identity
+    state.stopped_at = None
+    if state.started_at is None:
+        state.started_at = now
+    save_state(state)
+    return StartResult(
+        state=state,
+        version_from=prev_version,
+        version_to=new_version,
+    )
+
+
+def stop_service(slug: str, *, purge: bool = False) -> None:
+    slug = validate_slug(slug)
+    with service_lock(slug):
+        _stop_service_unlocked(slug, purge=purge)
+
+
+def _stop_service_unlocked(slug: str, *, purge: bool = False) -> None:
+    require_linux_supervision()
+    state = load_state(slug)
+    if state is None and not instance_dir(slug).exists():
+        raise ServiceError(f"Service '{slug}' is not started")
+
+    if state is not None:
+        state = _heal_state(state)
+        if state.status == ServiceStatus.RUNNING and state.process is not None:
+            obs = observe_process(state.process)
+            if obs is ProcessObservation.UNVERIFIABLE:
+                raise ServiceError(
+                    f"Service '{slug}' process is unverifiable "
+                    f"(pid={state.process.pid}). Refusing to stop/purge."
+                )
+            if obs is ProcessObservation.VERIFIED_RUNNING:
+                stop_daemon_identity(state.process)
+
+    if purge:
+        d = instance_dir(slug)
+        root = _services_root()
+        resolved = d.resolve()
+        try:
+            resolved.relative_to(root)
+        except ValueError as e:
+            raise ServiceError("Refusing to purge path outside services directory") from e
+        if resolved == root or resolved.name.startswith("."):
+            raise ServiceError("Refusing to purge services root or lock directory")
+        import shutil
+
+        if resolved.is_dir():
+            shutil.rmtree(resolved)
+        return
+
+    if state is not None:
+        state.status = ServiceStatus.STOPPED
+        state.process = None
+        state.stopped_at = datetime.now(UTC).isoformat()
+        save_state(state)
+
+
+@dataclass
+class ServiceStatusView:
+    state: ServiceState
+    observation: ProcessObservation
+    log_tail: str
+    role_path: Path | None
+    last_run_at: str | None = None
+    last_run_ok: bool | None = None
+    cost_today_usd: float | None = None
+    unverifiable_message: str | None = None
+
+
+def status(slug: str) -> ServiceStatusView:
+    slug = validate_slug(slug)
+    state = load_state(slug)
+    if state is None:
+        raise ServiceError(f"Service '{slug}' is not started")
+
+    obs = observe_process(state.process) if state.process else ProcessObservation.VERIFIED_DEAD
+    unverifiable_message = None
+    if state.status == ServiceStatus.RUNNING:
+        if obs is ProcessObservation.VERIFIED_DEAD:
+            state = _heal_state(state)
+            obs = ProcessObservation.VERIFIED_DEAD
+        elif obs is ProcessObservation.UNVERIFIABLE:
+            unverifiable_message = (
+                f"Process pid={state.process.pid if state.process else '?'} is alive "
+                "but identity cannot be verified"
+            )
+
+    role: Path | None = None
+    try:
+        role = role_path_for_state(state) if state.role_file else None
+    except ServiceError:
+        role = None
+
+    last_run_at, last_run_ok, cost = _audit_snapshot(runtime_agent_name(slug))
+
+    return ServiceStatusView(
+        state=state,
+        observation=obs,
+        log_tail=_tail_log(slug, lines=15),
+        role_path=role,
+        last_run_at=last_run_at,
+        last_run_ok=last_run_ok,
+        cost_today_usd=cost,
+        unverifiable_message=unverifiable_message,
+    )
+
+
+def _audit_snapshot(
+    agent_name: str,
+) -> tuple[str | None, bool | None, float | None]:
+    last_run_at: str | None = None
+    last_run_ok: bool | None = None
+    cost: float | None = None
+    try:
+        from initrunner.services.operations import query_audit_sync
+
+        rows = query_audit_sync(agent_name=agent_name, limit=1)
+        if rows:
+            rec = rows[0]
+            last_run_at = getattr(rec, "timestamp", None) or None
+            # Prefer explicit success/error fields when present
+            err = getattr(rec, "error", None)
+            if err is not None:
+                last_run_ok = not bool(err)
+            else:
+                last_run_ok = True
+    except Exception:
+        _logger.debug("audit snapshot failed", exc_info=True)
+
+    try:
+        from initrunner.services.cost import cost_report_sync
+
+        today = datetime.now(UTC).strftime("%Y-%m-%dT00:00:00+00:00")
+        report = cost_report_sync(agent_name=agent_name, since=today)
+        cost = report.total_cost_usd
+    except Exception:
+        _logger.debug("cost snapshot failed", exc_info=True)
+
+    return last_run_at, last_run_ok, cost
+
+
+def service_logs(slug: str, *, lines: int = 50) -> str:
+    slug = validate_slug(slug)
+    if not instance_dir(slug).exists():
+        raise ServiceError(f"Service '{slug}' is not started")
+    return _tail_log(slug, lines=lines)
+
+
+@dataclass
+class ForcedRunResult:
+    exit_code: int
+    was_running: bool
+    restart_error: str | None = None
+    messages: list[str] = field(default_factory=list)
+
+
+def forced_run(
+    slug: str,
+    *,
+    model: str | None = None,
+    extra_dirs: list[Path] | None = None,
+) -> ForcedRunResult:
+    """One-shot tick with concurrency rules under lifecycle lock."""
+    slug = validate_slug(slug)
+    with service_lock(slug):
+        return _forced_run_unlocked(slug, model=model, extra_dirs=extra_dirs)
+
+
+def _forced_run_unlocked(
+    slug: str,
+    *,
+    model: str | None = None,
+    extra_dirs: list[Path] | None = None,
+) -> ForcedRunResult:
+    require_linux_supervision()
+    state = load_state(slug)
+    if state is None:
+        raise ServiceError(f"Service '{slug}' is not started")
+    state = _heal_state(state)
+
+    was_running = False
+    if state.status == ServiceStatus.RUNNING and state.process is not None:
+        obs = observe_process(state.process)
+        if obs is ProcessObservation.UNVERIFIABLE:
+            raise ServiceError(f"Service '{slug}' process is unverifiable; aborting run.")
+        if obs is ProcessObservation.VERIFIED_RUNNING:
+            was_running = True
+            stop_daemon_identity(state.process)
+            state.status = ServiceStatus.STOPPED
+            state.process = None
+            state.stopped_at = datetime.now(UTC).isoformat()
+            save_state(state)
+
+    role = role_path_for_state(state)
+    prompt, autonomous = _prompt_from_role(role)
+
+    cmd = [sys.executable, "-m", "initrunner", "run", str(role), "-p", prompt]
+    if autonomous:
+        cmd.append("-a")
+    if model:
+        cmd.extend(["--model", model])
+    tick = subprocess.run(cmd, check=False)
+    tick_code = tick.returncode
+
+    restart_error: str | None = None
+    messages: list[str] = []
+    if was_running:
+        try:
+            _start_service_unlocked(slug, extra_dirs=extra_dirs, has_overrides=False)
+        except ServiceError as e:
+            restart_error = str(e)
+            messages.append(f"restart failed: {e}")
+            st = load_state(slug)
+            if st is not None:
+                st.status = ServiceStatus.STOPPED
+                st.process = None
+                st.last_error = restart_error
+                save_state(st)
+
+    if tick_code != 0:
+        messages.insert(0, f"tick failed with exit code {tick_code}")
+        exit_code = tick_code
+    elif restart_error:
+        exit_code = 1
+    else:
+        exit_code = 0
+    return ForcedRunResult(
+        exit_code=exit_code,
+        was_running=was_running,
+        restart_error=restart_error,
+        messages=messages,
+    )
+
+
+def _prompt_from_role(role_path: Path) -> tuple[str, bool]:
+    prompt = "Run the scheduled service task."
+    autonomous = False
+    try:
+        data = yaml.safe_load(role_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return prompt, autonomous
+    if not isinstance(data, dict):
+        return prompt, autonomous
+    for t in data.get("spec", {}).get("triggers") or []:
+        if isinstance(t, dict) and t.get("type") == "cron":
+            prompt = str(t.get("prompt") or prompt)
+            autonomous = bool(t.get("autonomous", False))
+            break
+    if data.get("spec", {}).get("autonomy") is not None:
+        autonomous = True
+    return prompt, autonomous
+
+
+def info_dict(slug: str, *, extra_dirs: list[Path] | None = None) -> dict[str, Any]:
+    entry = get_catalog_entry(slug, extra_dirs=extra_dirs)
+    d = entry.definition
+    state = load_state(slug)
+    if state is not None:
+        state = _heal_state(state)
+    params_out = {}
+    for name, p in d.spec.params.items():
+        params_out[name] = {
+            "type": p.type.value,
+            "required": p.required,
+            "default": p.default,
+            "description": p.description,
+            "values": p.values or None,
+        }
+    return {
+        "slug": slug,
+        "version": d.metadata.version,
+        "description": d.metadata.description,
+        "source": entry.source,
+        "path": str(entry.path),
+        "primary_param": d.spec.primary_param,
+        "every": d.spec.every,
+        "params": params_out,
+        "requires": {
+            "env": d.spec.requires.env,
+            "extras": d.spec.requires.extras,
+        },
+        "defaults": {
+            "autonomy": d.spec.defaults.autonomy,
+            "timezone": d.spec.defaults.timezone,
+        },
+        "status": state.status.value if state else ServiceStatus.STOPPED.value,
+        "active_params": state.params if state else {},
+        "runtime_agent_name": runtime_agent_name(slug),
+    }

--- a/tests/cli/test_service_cmd.py
+++ b/tests/cli/test_service_cmd.py
@@ -1,0 +1,116 @@
+"""CLI tests for always-on services."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from initrunner.agent.schema.service import ProcessIdentity, ServiceState, ServiceStatus
+from initrunner.cli.main import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("INITRUNNER_HOME", str(tmp_path / "home"))
+    from initrunner.config import get_home_dir
+
+    get_home_dir.cache_clear()
+    yield tmp_path / "home"
+    get_home_dir.cache_clear()
+
+
+def test_help_lists_service() -> None:
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "service" in result.stdout
+    # Panel name appears in rich help
+    assert "Always-on" in result.stdout or "service" in result.stdout
+
+
+def test_service_list(home: Path) -> None:
+    result = runner.invoke(app, ["service", "list"])
+    assert result.exit_code == 0
+    assert "collector" in result.stdout
+
+
+def test_service_info_collector(home: Path) -> None:
+    result = runner.invoke(app, ["service", "info", "collector"])
+    assert result.exit_code == 0
+    assert "target" in result.stdout
+    assert "service-collector" in result.stdout
+
+
+def test_malicious_slug_rejected(home: Path) -> None:
+    result = runner.invoke(app, ["service", "status", "../etc"])
+    assert result.exit_code != 0
+
+
+def test_start_positional_and_set_conflict(home: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "service",
+            "start",
+            "collector",
+            "acme.com",
+            "--set",
+            "target=other.com",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "not both" in result.stdout.lower() or "Error" in result.stdout
+
+
+def test_duplicate_set_rejected(home: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "service",
+            "start",
+            "collector",
+            "--set",
+            "target=a",
+            "--set",
+            "target=b",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Duplicate" in result.stdout
+
+
+def test_start_success_message(home: Path) -> None:
+    state = ServiceState(
+        slug="collector",
+        service_version="1.0.0",
+        status=ServiceStatus.RUNNING,
+        params={"target": "acme.com"},
+        every="daily",
+        resolved_cron="0 6 * * *",
+        timezone="UTC",
+        generation=1,
+        role_file="role.1.yaml",
+        process=ProcessIdentity(
+            pid=4242,
+            boot_id="b",
+            proc_start_ticks=1,
+            role_path="/tmp/role.1.yaml",
+        ),
+        output_paths=["/tmp/out.md"],
+    )
+    from initrunner.services.always_on import StartResult
+
+    with patch(
+        "initrunner.services.always_on.start_service",
+        return_value=StartResult(state=state),
+    ):
+        # get_catalog_entry still runs for primary param
+        result = runner.invoke(app, ["service", "start", "collector", "acme.com"])
+    assert result.exit_code == 0
+    assert "Started" in result.stdout or "running" in result.stdout.lower()
+    assert "acme.com" in result.stdout
+    assert "/tmp/out.md" in result.stdout

--- a/tests/services/test_always_on.py
+++ b/tests/services/test_always_on.py
@@ -1,0 +1,437 @@
+"""Tests for always-on service lifecycle."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+
+from initrunner.agent.schema.service import ProcessIdentity, ServiceStatus
+from initrunner.services.always_on import (
+    ProcessObservation,
+    ServiceError,
+    check_requires,
+    discover_catalog,
+    forced_run,
+    get_catalog_entry,
+    instance_dir,
+    list_services,
+    load_state,
+    materialize_instance_role,
+    observe_process,
+    parse_sink_specs,
+    resolve_every,
+    resolve_params,
+    runtime_agent_name,
+    set_daemon_launcher,
+    start_service,
+    status,
+    stop_service,
+    validate_slug,
+)
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("INITRUNNER_HOME", str(tmp_path / "home"))
+    from initrunner.config import get_home_dir
+
+    get_home_dir.cache_clear()
+    yield tmp_path / "home"
+    get_home_dir.cache_clear()
+    set_daemon_launcher(None)
+
+
+@pytest.fixture
+def catalog(tmp_path: Path) -> Path:
+    """Minimal fake catalog with one service."""
+    root = tmp_path / "catalog" / "probe"
+    root.mkdir(parents=True)
+    (root / "service.yaml").write_text(
+        """
+apiVersion: initrunner/v1
+kind: Service
+metadata:
+  name: probe
+  version: "0.1.0"
+  description: Test service
+spec:
+  entry:
+    kind: Agent
+    path: role.yaml
+  primary_param: target
+  every: hourly
+  params:
+    target:
+      type: string
+      required: true
+    alert_severity:
+      type: enum
+      values: [low, medium, high]
+      default: medium
+  defaults:
+    autonomy: false
+    sinks:
+      - type: file
+        path: out.md
+        format: text
+    guardrails:
+      max_tokens_per_run: 1000
+    timezone: UTC
+  requires:
+    env: []
+    extras: []
+  schedule_prompt: "Check {{ params.target }}"
+""",
+        encoding="utf-8",
+    )
+    (root / "role.yaml").write_text(
+        """
+apiVersion: initrunner/v1
+kind: Agent
+metadata:
+  name: probe
+  description: test
+spec:
+  role: |
+    You monitor {{ params.target }}.
+  tools:
+    - type: datetime
+  triggers:
+    - type: cron
+      schedule: "0 * * * *"
+      prompt: "tick"
+  guardrails:
+    max_tokens_per_run: 1000
+""",
+        encoding="utf-8",
+    )
+    return tmp_path / "catalog"
+
+
+def _fake_launcher_factory(identity_hook=None):
+    """Return a launcher that spawns `sleep 60` and records the role path in argv."""
+
+    def launcher(role_path: Path, log_path: Path, cwd: Path, env: dict) -> int:
+        # Put role path in cmdline so collect_process_identity can match.
+        proc = __import__("subprocess").Popen(
+            ["sleep", "60", str(role_path.resolve())],
+            stdout=open(log_path, "ab"),
+            stderr=__import__("subprocess").STDOUT,
+            cwd=str(cwd),
+            env=env,
+            start_new_session=True,
+        )
+        if identity_hook:
+            identity_hook(proc.pid, role_path)
+        return proc.pid
+
+    return launcher
+
+
+@pytest.fixture
+def fake_daemon(monkeypatch: pytest.MonkeyPatch):
+    """Use sleep child + patched identity collection for Linux tests."""
+
+    def launcher(role_path: Path, log_path: Path, cwd: Path, env: dict) -> int:
+        import sys
+
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(log_path, "ab") as log_f:
+            # Put role path in argv so real identity checks can match; sleep
+            # must not treat it as a duration (GNU sleep does).
+            proc = __import__("subprocess").Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    "import time,sys; time.sleep(120)",
+                    str(role_path.resolve()),
+                ],
+                stdout=log_f,
+                stderr=__import__("subprocess").STDOUT,
+                cwd=str(cwd),
+                env=env,
+                start_new_session=True,
+            )
+        return proc.pid
+
+    set_daemon_launcher(launcher)
+
+    def fake_collect(pid: int, role_path: str) -> ProcessIdentity | None:
+        if not Path(f"/proc/{pid}").exists() and os.name == "posix":
+            # still try kill 0
+            try:
+                os.kill(pid, 0)
+            except OSError:
+                return None
+        return ProcessIdentity(
+            pid=pid,
+            boot_id="test-boot",
+            proc_start_ticks=1,
+            role_path=str(Path(role_path).resolve()),
+            started_at="2026-01-01T00:00:00+00:00",
+        )
+
+    def fake_observe(identity: ProcessIdentity | None) -> ProcessObservation:
+        if identity is None:
+            return ProcessObservation.VERIFIED_DEAD
+        from initrunner.services.always_on import _pid_alive
+
+        if _pid_alive(identity.pid):
+            return ProcessObservation.VERIFIED_RUNNING
+        return ProcessObservation.VERIFIED_DEAD
+
+    monkeypatch.setattr("initrunner.services.always_on.collect_process_identity", fake_collect)
+    monkeypatch.setattr("initrunner.services.always_on.observe_process", fake_observe)
+    monkeypatch.setattr("initrunner.services.always_on.require_linux_supervision", lambda: None)
+    yield
+    set_daemon_launcher(None)
+
+
+def test_validate_slug() -> None:
+    assert validate_slug("collector") == "collector"
+    with pytest.raises(ServiceError):
+        validate_slug("../etc")
+    with pytest.raises(ServiceError):
+        validate_slug("/tmp/x")
+    with pytest.raises(ServiceError):
+        validate_slug("foo/bar")
+    with pytest.raises(ServiceError):
+        validate_slug("UPPER")
+
+
+def test_instance_dir_containment(home: Path) -> None:
+    d = instance_dir("collector")
+    assert d.name == "collector"
+    assert "services" in d.parts
+
+
+def test_discover_shipped_collector() -> None:
+    entries = discover_catalog()
+    slugs = {e.slug for e in entries}
+    assert "collector" in slugs
+    assert "researcher" not in slugs
+
+
+def test_discover_extra_catalog(catalog: Path, home: Path) -> None:
+    entries = discover_catalog(extra_dirs=[catalog])
+    assert any(e.slug == "probe" for e in entries)
+    entry = get_catalog_entry("probe", extra_dirs=[catalog])
+    assert entry.definition.metadata.version == "0.1.0"
+    assert entry.definition.spec.primary_param == "target"
+
+
+def test_resolve_params_and_every(catalog: Path) -> None:
+    entry = get_catalog_entry("probe", extra_dirs=[catalog])
+    with pytest.raises(ServiceError, match="Missing required"):
+        resolve_params(entry.definition, {})
+    resolved = resolve_params(entry.definition, {"target": "acme.com"})
+    assert resolved["target"] == "acme.com"
+    assert resolved["alert_severity"] == "medium"
+    assert resolve_every("daily") == "0 6 * * *"
+    assert resolve_every("0 */2 * * *") == "0 */2 * * *"
+    with pytest.raises(ServiceError, match="Invalid schedule"):
+        resolve_every("not-a-schedule")
+
+
+def test_parse_sink_specs() -> None:
+    sinks = parse_sink_specs(["file:/tmp/a.md", "webhook:https://example.com/h"])
+    assert sinks[0] == {"type": "file", "path": "/tmp/a.md", "format": "text"}
+    assert sinks[1]["type"] == "webhook"
+    with pytest.raises(ServiceError, match="Unknown sink"):
+        parse_sink_specs(["slack:#ops"])
+
+
+def test_materialize_runtime_name_and_sinks(catalog: Path, home: Path, tmp_path: Path) -> None:
+    entry = get_catalog_entry("probe", extra_dirs=[catalog])
+    dest = tmp_path / "role.1.yaml"
+    params = resolve_params(entry.definition, {"target": "acme.com"})
+    digest, sinks = materialize_instance_role(
+        entry,
+        params,
+        [{"type": "file", "path": "brief.md", "format": "text"}],
+        every="hourly",
+        resolved_cron="0 * * * *",
+        timezone="UTC",
+        dest=dest,
+    )
+    assert digest
+    text = dest.read_text(encoding="utf-8")
+    assert "acme.com" in text
+    data = yaml.safe_load(text)
+    assert data["metadata"]["name"] == "service-probe"
+    assert runtime_agent_name("probe") == "service-probe"
+    cron = data["spec"]["triggers"][0]
+    assert cron["schedule"] == "0 * * * *"
+    assert "brief.md" in sinks[0]["path"]
+    assert "data" in sinks[0]["path"]
+
+
+def test_materialize_rejects_dotdot_sink(catalog: Path, home: Path, tmp_path: Path) -> None:
+    entry = get_catalog_entry("probe", extra_dirs=[catalog])
+    dest = tmp_path / "role.1.yaml"
+    params = resolve_params(entry.definition, {"target": "x"})
+    with pytest.raises(ServiceError, match="\\.\\."):
+        materialize_instance_role(
+            entry,
+            params,
+            [{"type": "file", "path": "../escape.md", "format": "text"}],
+            every="daily",
+            resolved_cron="0 6 * * *",
+            timezone="UTC",
+            dest=dest,
+        )
+
+
+def test_start_stop_purge(catalog: Path, home: Path, fake_daemon) -> None:
+    result = start_service(
+        "probe",
+        params={"target": "example.com"},
+        extra_dirs=[catalog],
+    )
+    assert result.state.status == ServiceStatus.RUNNING
+    assert result.state.process is not None
+    pid = result.state.process.pid
+    assert result.state.params["target"] == "example.com"
+    assert result.state.every == "hourly"
+
+    # Idempotent start
+    again = start_service("probe", extra_dirs=[catalog])
+    assert again.idempotent
+
+    # Reconfig while running rejected
+    with pytest.raises(ServiceError, match="already running"):
+        start_service(
+            "probe",
+            params={"target": "other.com"},
+            extra_dirs=[catalog],
+        )
+
+    stop_service("probe")
+    st = load_state("probe")
+    assert st is not None
+    assert st.status == ServiceStatus.STOPPED
+    # child should be dead (brief wait for reaping)
+    deadline = time.time() + 2.0
+    alive = True
+    while time.time() < deadline:
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            alive = False
+            break
+        time.sleep(0.05)
+    assert not alive
+
+    # Restart without overrides
+    resumed = start_service("probe", extra_dirs=[catalog])
+    assert resumed.state.status == ServiceStatus.RUNNING
+
+    stop_service("probe", purge=True)
+    assert load_state("probe") is None
+    assert not instance_dir("probe").exists()
+
+
+def test_list_healed_status(catalog: Path, home: Path, fake_daemon) -> None:
+    start_service(
+        "probe",
+        params={"target": "z"},
+        extra_dirs=[catalog],
+    )
+    items = list_services(extra_dirs=[catalog])
+    probe = next(i for i in items if i.slug == "probe")
+    assert probe.status == ServiceStatus.RUNNING
+
+
+def test_status_not_started(home: Path) -> None:
+    with pytest.raises(ServiceError, match="not started"):
+        status("nope")
+
+
+def test_check_requires_search_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    entry = get_catalog_entry("collector")
+    real_import = __import__
+
+    def fake_import(name: str, *args: object, **kwargs: object):
+        if name == "ddgs":
+            raise ImportError("nope")
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+    missing = check_requires(entry.definition)
+    assert any("search" in m for m in missing)
+
+
+def test_shipped_collector_role_validates(home: Path, tmp_path: Path) -> None:
+    from initrunner.agent.loader import load_role
+
+    entry = get_catalog_entry("collector")
+    dest = tmp_path / "role.1.yaml"
+    params = resolve_params(entry.definition, {"target": "example.com", "alert_severity": "high"})
+    materialize_instance_role(
+        entry,
+        params,
+        None,
+        every="daily",
+        resolved_cron="0 6 * * *",
+        timezone="UTC",
+        dest=dest,
+    )
+    role = load_role(dest)
+    assert role.metadata.name == "service-collector"
+    assert "example.com" in role.spec.role
+    assert role.spec.triggers
+
+
+def test_observe_dead_when_none() -> None:
+    assert observe_process(None) is ProcessObservation.VERIFIED_DEAD
+
+
+def test_forced_run_stopped(
+    catalog: Path, home: Path, fake_daemon, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    start_service("probe", params={"target": "t"}, extra_dirs=[catalog])
+    stop_service("probe")
+
+    def fake_run(cmd, check=False):
+        class R:
+            returncode = 0
+
+        return R()
+
+    monkeypatch.setattr("initrunner.services.always_on.subprocess.run", fake_run)
+    result = forced_run("probe", extra_dirs=[catalog])
+    assert result.exit_code == 0
+    assert result.was_running is False
+    st = load_state("probe")
+    assert st is not None
+    assert st.status == ServiceStatus.STOPPED
+
+
+def test_forced_run_running_restarts(
+    catalog: Path, home: Path, fake_daemon, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    start_service("probe", params={"target": "t"}, extra_dirs=[catalog])
+
+    def fake_run(cmd, check=False):
+        class R:
+            returncode = 0
+
+        return R()
+
+    monkeypatch.setattr("initrunner.services.always_on.subprocess.run", fake_run)
+    result = forced_run("probe", extra_dirs=[catalog])
+    assert result.exit_code == 0
+    assert result.was_running is True
+    st = load_state("probe")
+    assert st is not None
+    assert st.status == ServiceStatus.RUNNING
+    stop_service("probe", purge=True)
+
+
+def test_purge_refuses_bad_slug(home: Path) -> None:
+    with pytest.raises(ServiceError):
+        stop_service("../x", purge=True)


### PR DESCRIPTION
## Summary

- Add **`initrunner service`** (Always-on panel): list / info / start / status / run / stop / logs for curated always-on agents without writing YAML.
- Ship the **`collector`** catalog service (scheduled target monitoring); requires `initrunner[search]` and a configured provider on Linux.
- Operate-time safety: slug containment, process identity before signal, lifecycle locks outside instance dirs, generationed roles, status heal + audit/cost snapshot.
- Docs: `docs/agents/services.md`, CLI table, README blurb, CHANGELOG draft for **2026.7.6** (version bump left for the release PR).

## Test plan

- [x] `uv run pytest tests/services/test_always_on.py tests/cli/test_service_cmd.py` (24 passed)
- [x] ruff + ty on new modules
- [x] `uv build` wheel includes `service_catalog/collector/{service,role}.yaml`
- [x] Manual e2e: start → status → run with OpenAI → stop --purge
- [ ] CI green on this PR

## Release follow-up

After merge: `scripts/release.sh 2026.7.6` → `release/2026.7.6` PR → retag merge commit → `git push origin v2026.7.6`.