### PR TITLE
docs: name initrunner in every container command

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -82,7 +82,7 @@ initrunner run --ingest ./docs/    # YAML をスキップして、ドキュメ�
 **Docker:**
 
 ```bash
-docker run --rm -it -e OPENAI_API_KEY ghcr.io/vladkesler/initrunner:latest run -i
+docker run --rm -it -e OPENAI_API_KEY ghcr.io/vladkesler/initrunner:latest initrunner run -i
 ```
 
 ## 1つのファイル、4つのモード

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Browse community agents at [InitHub](https://hub.initrunner.ai/): `initrunner se
 **Docker:**
 
 ```bash
-docker run --rm -it -e OPENAI_API_KEY ghcr.io/vladkesler/initrunner:latest run -i
+docker run --rm -it -e OPENAI_API_KEY ghcr.io/vladkesler/initrunner:latest initrunner run -i
 ```
 
 ## One file, four modes

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -82,7 +82,7 @@ initrunner run --ingest ./docs/    # 跳过 YAML，直接和你的文档聊天
 **Docker:**
 
 ```bash
-docker run --rm -it -e OPENAI_API_KEY ghcr.io/vladkesler/initrunner:latest run -i
+docker run --rm -it -e OPENAI_API_KEY ghcr.io/vladkesler/initrunner:latest initrunner run -i
 ```
 
 ## 一个文件，四种模式

--- a/docs/getting-started/docker.md
+++ b/docs/getting-started/docker.md
@@ -12,6 +12,26 @@ memory or ingestion. It also runs ~38 MB lighter, because the MCP client stack
 loads whether or not a role uses it. A role that needs a missing extra fails at
 load with the `uv pip install` line, so switching tags never fails silently.
 
+One catch on `slim`: ephemeral mode (`initrunner run` with no role file) turns
+on persistent memory by default, and that needs the vector extra. Pass
+`--no-memory` to run it on `slim`, or use `latest`. Examples in this page that
+name a role file are unaffected.
+
+## Naming the command
+
+The image's default command is `initrunner dashboard --expose --no-open`, and
+its entrypoint runs whatever command it is given. Docker replaces the *whole*
+default command when you pass your own, so every example below spells out
+`initrunner` before the subcommand:
+
+```bash
+docker run ... ghcr.io/vladkesler/initrunner:latest run -i              # exec: run: not found
+docker run ... ghcr.io/vladkesler/initrunner:latest initrunner run -i   # correct
+```
+
+The same applies to `command:` in Compose and to `command:`/`args:` in a
+Kubernetes pod spec.
+
 ## API keys
 
 The container needs API keys to reach your LLM provider. Three ways to pass them:
@@ -37,16 +57,16 @@ All examples below use `-e OPENAI_API_KEY` for brevity. Replace with `--env-file
 ```bash
 # Interactive chat with memory
 docker run --rm -it -e OPENAI_API_KEY \
-    -v initrunner-data:/data ghcr.io/vladkesler/initrunner:latest run -i
+    -v initrunner-data:/data ghcr.io/vladkesler/initrunner:latest initrunner run -i
 
 # Chat with cherry-picked tools
 docker run --rm -it -e OPENAI_API_KEY \
     -v initrunner-data:/data -v .:/workspace \
     ghcr.io/vladkesler/initrunner:latest \
-    run -i --tools git --tools filesystem
+    initrunner run -i --tools git --tools filesystem
 
 # Enable all built-in tools at once
-#   run -i --tool-profile all
+#   initrunner run -i --tool-profile all
 ```
 
 ## RAG (document chat)
@@ -55,15 +75,15 @@ docker run --rm -it -e OPENAI_API_KEY \
 # Chat with your documents (instant RAG)
 docker run --rm -it -e OPENAI_API_KEY \
     -v initrunner-data:/data -v ./docs:/docs \
-    ghcr.io/vladkesler/initrunner:latest run -i --ingest /docs
+    ghcr.io/vladkesler/initrunner:latest initrunner run -i --ingest /docs
 
 # Ingest documents for a role, then query
 docker run --rm -e OPENAI_API_KEY \
     -v ./roles:/roles -v ./docs:/docs -v initrunner-data:/data \
-    ghcr.io/vladkesler/initrunner:latest ingest /roles/rag-agent.yaml
+    ghcr.io/vladkesler/initrunner:latest initrunner ingest /roles/rag-agent.yaml
 docker run --rm -it -e OPENAI_API_KEY \
     -v ./roles:/roles -v initrunner-data:/data \
-    ghcr.io/vladkesler/initrunner:latest run /roles/rag-agent.yaml -i
+    ghcr.io/vladkesler/initrunner:latest initrunner run /roles/rag-agent.yaml -i
 ```
 
 ## Telegram bot
@@ -71,7 +91,7 @@ docker run --rm -it -e OPENAI_API_KEY \
 ```bash
 docker run -d -e OPENAI_API_KEY -e TELEGRAM_BOT_TOKEN \
     -v initrunner-data:/data ghcr.io/vladkesler/initrunner:latest \
-    run --bot telegram
+    initrunner run --bot telegram
 ```
 
 ## API server
@@ -80,7 +100,7 @@ docker run -d -e OPENAI_API_KEY -e TELEGRAM_BOT_TOKEN \
 # OpenAI-compatible API server on port 8000
 docker run -d -e OPENAI_API_KEY -v ./roles:/roles \
     -p 8000:8000 ghcr.io/vladkesler/initrunner:latest \
-    run /roles/my-agent.yaml --serve --host 0.0.0.0
+    initrunner run /roles/my-agent.yaml --serve --host 0.0.0.0
 ```
 
 ## Web dashboard
@@ -91,7 +111,7 @@ This is the image default (`CMD`). `--expose` binds `0.0.0.0` and generates an A
 # Web dashboard at http://localhost:8100
 docker run -d -e OPENAI_API_KEY -v ./roles:/roles -v initrunner-data:/data \
     -p 8100:8100 ghcr.io/vladkesler/initrunner:latest \
-    dashboard --expose --no-open --roles-dir /roles
+    initrunner dashboard --expose --no-open --roles-dir /roles
 ```
 
 ## Using a different provider or model
@@ -103,7 +123,7 @@ docker run --rm -it \
     -e OPENAI_API_KEY=sk-or-your-openrouter-key \
     -e OPENAI_BASE_URL=https://openrouter.ai/api/v1 \
     -e INITRUNNER_MODEL=openai:google/gemini-3-flash-preview \
-    -v initrunner-data:/data ghcr.io/vladkesler/initrunner:latest run -i
+    -v initrunner-data:/data ghcr.io/vladkesler/initrunner:latest initrunner run -i
 ```
 
 Or use any supported provider directly:
@@ -111,11 +131,11 @@ Or use any supported provider directly:
 ```bash
 # Anthropic
 docker run --rm -it -e ANTHROPIC_API_KEY \
-    -v initrunner-data:/data ghcr.io/vladkesler/initrunner:latest run -i
+    -v initrunner-data:/data ghcr.io/vladkesler/initrunner:latest initrunner run -i
 
 # Google
 docker run --rm -it -e GOOGLE_API_KEY \
-    -v initrunner-data:/data ghcr.io/vladkesler/initrunner:latest run -i
+    -v initrunner-data:/data ghcr.io/vladkesler/initrunner:latest initrunner run -i
 ```
 
 ## Docker Compose
@@ -238,7 +258,7 @@ docker run --rm -it \
     -v ./roles:/roles \
     -v initrunner-data:/data \
     ghcr.io/vladkesler/initrunner:latest \
-    run /roles/my-sandboxed-agent.yaml -p "compute 2**100"
+    initrunner run /roles/my-sandboxed-agent.yaml -p "compute 2**100"
 ```
 
 Or in `docker-compose.yml`, uncomment the socket volume:

--- a/docs/operations/logging.md
+++ b/docs/operations/logging.md
@@ -96,7 +96,7 @@ INITRUNNER_LOG_LEVEL=DEBUG initrunner run role.yaml -p "ping"
 services:
   agent:
     image: ghcr.io/vladkesler/initrunner:latest
-    command: ["a2a", "serve", "/app/role.yaml"]
+    command: ["initrunner", "a2a", "serve", "/app/role.yaml"]
     environment:
       INITRUNNER_LOG_LEVEL: DEBUG
 ```

--- a/docs/orchestration/groups.md
+++ b/docs/orchestration/groups.md
@@ -173,7 +173,7 @@ $ initrunner validate desk.yaml
 
 ## Deploying with Kubernetes or Argo CD
 
-Bake or mount the group file next to its role files and point the container at the group. Nothing about the image is group-specific: it is the normal InitRunner image with a different argument. Without a group file, point it at the directory instead -- `args: ["run", "/agents", "--serve", "--host", "0.0.0.0"]` -- and adding an agent is one new file in the ConfigMap.
+Bake or mount the group file next to its role files and point the container at the group. Nothing about the image is group-specific: it is the normal InitRunner image with a different argument. Without a group file, point it at the directory instead -- `args: ["initrunner", "run", "/agents", "--serve", "--host", "0.0.0.0"]` -- and adding an agent is one new file in the ConfigMap.
 
 ```yaml
 apiVersion: apps/v1
@@ -191,7 +191,7 @@ spec:
       containers:
         - name: initrunner
           image: ghcr.io/vladkesler/initrunner:latest
-          args: ["run", "/agents/desk.yaml", "--serve", "--host", "0.0.0.0"]
+          args: ["initrunner", "run", "/agents/desk.yaml", "--serve", "--host", "0.0.0.0"]
           env:
             - name: INITRUNNER_API_KEY
               valueFrom:


### PR DESCRIPTION
## The bug

The image entrypoint ends in `exec "$@"` and the default command is
`initrunner dashboard --expose --no-open`. Docker replaces the *whole* default
command when you pass your own, so the documented quick start:

```bash
docker run --rm -it -e OPENAI_API_KEY ghcr.io/vladkesler/initrunner:latest run -i
```

execs `run -i` and dies:

```
/usr/local/bin/docker-entrypoint.sh: 13: exec: run: not found
```

Anyone copying the Docker example out of the README hit this.

## What was wrong

- `docs/getting-started/docker.md`: Quick start, RAG, Telegram bot, API server, Web dashboard, provider selection, Docker sandbox
- `README.md`, `README.zh-CN.md`, `README.ja.md`: the Docker line
- `docs/operations/logging.md`: Compose `command:`
- `docs/orchestration/groups.md`: Kubernetes `args:`, both the snippet and the inline prose

The "Sizing the container" section was already correct, which is probably why this went unnoticed.

## Also added

- A short "Naming the command" section explaining the override rule, so the examples do not get shortened back later.
- A note that ephemeral mode (`initrunner run` with no role file) enables persistent memory by default and so needs `--no-memory` on `slim`, which ships without the vector extra.

## Verification

Everything was run against `ghcr.io/vladkesler/initrunner:slim` at 2026.8.9:

| Check | Result |
|---|---|
| `initrunner run <role> -p ...` | works |
| `initrunner run --no-memory -p ...` (ephemeral) | works |
| `initrunner run <role> --serve` + `/health` + `/v1/chat/completions` | works |
| `initrunner dashboard --expose` + `/api/health` | HTTP 200 |
| Compose `command: ["initrunner", "validate", ...]` | `Valid` |
| Compose `command: ["validate", ...]` (old form) | `exec: validate: not found` |
| `... :slim run -i` (old form) | `exec: run: not found` |

Docs only. No version bump.

https://claude.ai/code/session_01NSaugLDcim9CphRdgHjFTP