### PR TITLE
fix: ephemeral mode names the missing extra instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- **Ephemeral mode crashed instead of naming the missing extra.** `initrunner run -p "hi"` with no role file turns persistent memory on by default, which needs the vector extra. On a core install or the `slim` image that ended in a Rich traceback, where `initrunner run role.yaml` with the same `memory:` block prints one clean line. The loader wraps `MissingExtraError` in `RoleLoadError` so the hint surfaces at load rather than mid-run, and the role-file path catches it in `load_and_build_or_exit`; the REPL/one-shot and `--bot` paths called `build_agent` bare. Both now go through one helper that prints the install line and, when memory is the only thing asking for the extra, adds `Add --no-memory to run without it`, because the user never wrote `memory:` and may be in a container where `pip install` is not an option. `--ingest` still needs the extra and says so without the flag hint. The `--bot` path also no longer opens the audit log before the agent is known to build.
+
 ## [2026.8.9] - 2026-08-21
 
 ### Changed (dependency layout)

--- a/initrunner/cli/_ephemeral.py
+++ b/initrunner/cli/_ephemeral.py
@@ -157,6 +157,31 @@ def verify_bot_sdk(platform: str) -> None:
         raise typer.Exit(1) from None
 
 
+def build_agent_or_exit(role):
+    """Build the agent, reporting a missing extra the way the role-file path does.
+
+    ``build_agent`` wraps ``MissingExtraError`` in ``RoleLoadError`` so the
+    install hint surfaces at load rather than mid-run. ``load_and_build_or_exit``
+    catches it for role files; this is the ephemeral twin. Nothing an ephemeral
+    role can carry needs the vector extra except memory and ingest, and memory
+    is on by default, so when ingest is not in play the hint names the flag
+    that turns memory off.
+    """
+    from initrunner._compat import MissingExtraError
+    from initrunner.agent.loader import RoleLoadError, build_agent
+
+    try:
+        return build_agent(role)
+    except RoleLoadError as e:
+        print_error(e)
+        if isinstance(e.__cause__, MissingExtraError) and role.spec.ingest is None:
+            console.print(
+                "[dim]Hint:[/dim] Persistent memory is what needs it."
+                " Add [bold]--no-memory[/bold] to run without it."
+            )
+        raise typer.Exit(1) from None
+
+
 # ---------------------------------------------------------------------------
 # Ingestion
 # ---------------------------------------------------------------------------
@@ -230,7 +255,6 @@ def dispatch_ephemeral_repl(
     api_key_env: str | None = None,
 ) -> None:
     """Build ephemeral role and run as REPL or one-shot."""
-    from initrunner.agent.loader import build_agent
     from initrunner.cli._helpers import ephemeral_context
     from initrunner.runner import run_interactive, run_single
     from initrunner.services.providers import build_quick_chat_role_sync
@@ -275,7 +299,7 @@ def dispatch_ephemeral_repl(
     else:
         ingest_config = None
 
-    agent = build_agent(role)
+    agent = build_agent_or_exit(role)
 
     console.print(f"[dim]Using {prov}:{mod}[/dim]")
     one_shot = bool(prompt) and not interactive
@@ -432,13 +456,12 @@ def dispatch_ephemeral_bot(
 
     role = build_ephemeral_role(prov, mod, **build_kwargs)
 
-    from initrunner.agent.loader import build_agent
     from initrunner.cli._helpers import create_audit_logger
     from initrunner.runner import run_daemon
     from initrunner.stores.factory import managed_memory_store
 
+    agent = build_agent_or_exit(role)
     audit_logger = create_audit_logger(audit_db, no_audit)
-    agent = build_agent(role)
 
     if ingest_config is not None:
         run_ephemeral_ingest(role, prov)

--- a/tests/test_lean_extras.py
+++ b/tests/test_lean_extras.py
@@ -9,6 +9,7 @@ identically whether or not the extras are installed.
 from __future__ import annotations
 
 import sys
+from unittest.mock import patch
 
 import pytest
 from typer.testing import CliRunner
@@ -209,3 +210,73 @@ class TestMissingExtraIsReportedOnce:
             cli_main.app_entry()
         assert exc.value.code == 1
         assert "initrunner[vector]" in capsys.readouterr().out
+
+
+class TestEphemeralModeReportsAMissingExtra:
+    """``initrunner run`` with no role file turns persistent memory on, which
+    needs the vector extra. It fails at load like the role-file path does, and
+    names the flag that runs without memory."""
+
+    @pytest.fixture(autouse=True)
+    def _env(self, monkeypatch, tmp_path):
+        # Detection prefers Anthropic, and that SDK is an extra; pin the
+        # provider to the one in core so the vector gate is what fires.
+        for var in (
+            "ANTHROPIC_API_KEY",
+            "GOOGLE_API_KEY",
+            "GROQ_API_KEY",
+            "MISTRAL_API_KEY",
+            "CO_API_KEY",
+            "XAI_API_KEY",
+            "INITRUNNER_MODEL",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        # Keep the developer's real ~/.initrunner/run.yaml and .env out of it.
+        monkeypatch.setenv("INITRUNNER_HOME", str(tmp_path / "home"))
+
+    def test_one_shot_names_the_extra_and_the_flag(self, no_lancedb):
+        from initrunner.cli.main import app
+
+        result = CliRunner().invoke(app, ["run", "-p", "hi", "--no-audit"])
+
+        flat = " ".join(result.output.split())
+        assert result.exit_code == 1
+        assert "initrunner[vector]" in flat
+        assert "--no-memory" in flat
+
+    def test_bot_path_reports_the_same_way(self, no_lancedb, monkeypatch):
+        """The SDK gate fires first on a lean install; step past it."""
+        from initrunner.cli.main import app
+
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "x")
+        with patch("initrunner.cli._ephemeral.verify_bot_sdk"):
+            result = CliRunner().invoke(app, ["run", "--bot", "telegram", "--no-audit"])
+
+        flat = " ".join(result.output.split())
+        assert result.exit_code == 1
+        assert "initrunner[vector]" in flat
+        assert "--no-memory" in flat
+
+    def test_ingest_needs_the_extra_whatever_memory_does(self, no_lancedb, tmp_path):
+        """Turning memory off would not help, so the flag is not offered."""
+        from initrunner.cli.main import app
+
+        result = CliRunner().invoke(
+            app, ["run", "-p", "hi", "--ingest", str(tmp_path / "docs"), "--no-audit"]
+        )
+
+        flat = " ".join(result.output.split())
+        assert result.exit_code == 1
+        assert "initrunner[vector]" in flat
+        assert "--no-memory" not in flat
+
+    def test_no_memory_runs_on_a_core_install(self, no_lancedb):
+        """The escape hatch the hint advertises has to work."""
+        from initrunner.cli.main import app
+
+        with patch("initrunner.runner.run_single") as run_single:
+            result = CliRunner().invoke(app, ["run", "-p", "hi", "--no-memory", "--no-audit"])
+
+        assert result.exit_code == 0, result.output
+        run_single.assert_called_once()


### PR DESCRIPTION
## The bug

`initrunner run -p "hi"` with no role file turns persistent memory on by default (`RunConfig.memory = True`), which needs the vector extra. On a core `pip install initrunner`, `--extras none`, or the `slim` Docker image, that ended in a raw Rich traceback:

```
RoleLoadError: 'lancedb' is required: uv pip install initrunner[vector]
```

`initrunner run role.yaml` with the same `memory:` block prints that one line cleanly and exits 1. 2026.8.9 promised exactly that ("fails when you load it, not mid-run, and the error carries the install command"); the ephemeral path was the one place it did not hold, and it is the first command a new user types.

## Root cause

`build_agent()` wraps `MissingExtraError` in `RoleLoadError` so the hint surfaces at load time (`agent/loader.py:793-798`). The role-file path catches it in `load_and_build_or_exit` (`cli/_helpers/_context.py`). The two ephemeral dispatchers called `build_agent(role)` bare (`cli/_ephemeral.py`, REPL/one-shot and `--bot`), so the `RoleLoadError` escaped to `app_entry`, whose only typed handler is `except MissingExtraError`, which no longer matches once the loader has re-wrapped it. Typer's pretty-exception hook did the rest.

## The fix

One helper, `build_agent_or_exit(role)`, beside `verify_bot_sdk` in the same module (the in-file precedent for `require -> except -> print_error -> Exit`). Both call sites use it. It prints the install line through `print_error` (which escapes `[vector]`) and, when memory is the only thing asking for the extra, adds:

```
Hint: Persistent memory is what needs it. Add --no-memory to run without it.
```

The condition is exact, not a heuristic: the ephemeral tool profiles carry neither `web_scraper` nor `mcp`, so the only `MissingExtraError` `build_agent` can raise for an ephemeral role comes from `_require_role_extras`, which fires on memory or ingest. With `--ingest` the extra is needed regardless and the flag hint is omitted. The user never wrote `memory:` and may be in a container where `pip install` is not an option, which is why the free way out is named.

Not falling back to memory-off silently: a REPL that quietly stops remembering between sessions is a worse failure than an error at startup, and it would cut against the no-silent-fallback principle the lean-core split was built on.

While there: the `--bot` path now builds the agent before opening the audit log, so a failed build no longer leaves an `AuditLogger` open.

## Tests

Four new tests in `tests/test_lean_extras.py`, so they run in the `test-lean` job on a real core install as well as masked (`no_lancedb`) in the matrix:

| Test | Asserts |
|---|---|
| one-shot `run -p hi` | exit 1, `initrunner[vector]` and `--no-memory` in output |
| `run --bot telegram` | same two strings (SDK gate patched past) |
| `run -p hi --ingest <dir>` | exit 1, `initrunner[vector]` present, `--no-memory` absent |
| `run -p hi --no-memory` | exit 0, `run_single` called once |

## Verification

Against `ghcr.io/vladkesler/initrunner:slim` 2026.8.9 with the modified module bind-mounted over the image's copy, real API keys:

```
$ ... initrunner run -p "hi"
Error: 'lancedb' is required: uv pip install initrunner[vector]
Hint: Persistent memory is what needs it. Add --no-memory to run without it.
exit=1

$ ... initrunner run -p "reply with the single word: working" --no-memory
Using openai:gpt-5-mini
working
exit=0
```

`uv run pytest tests/test_lean_extras.py tests/test_run_ephemeral.py` 61 passed. `ruff check`, `ruff format --check`, `ty check initrunner/` clean.

CHANGELOG entry under `## Unreleased`. Product change, so it needs a release to reach users; not cut here.

https://claude.ai/code/session_01NSaugLDcim9CphRdgHjFTP